### PR TITLE
Add batch visibility timeout updates (set_vt_batch and set_vt_multi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0 (Unreleased)
+
+### Message Operations
+- **[Feature]** Introduce `set_vt_batch(queue_name, msg_ids, vt_offset:)` for batch visibility timeout updates.
+- **[Feature]** Introduce `set_vt_multi(updates_hash, vt_offset:)` for updating visibility timeouts across multiple queues atomically.
+
 ## 0.3.0 (2025-11-14)
 
 Initial release of pgmq-ruby - a low-level Ruby client for PGMQ (PostgreSQL Message Queue).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | | `drop_queue` | Delete queue and all messages | ✅ |
 | | `detach_archive` | Detach archive table from queue | ✅ |
 | **Utilities** | `set_vt` | Update message visibility timeout | ✅ |
+| | `set_vt_batch` | Batch update visibility timeouts | ✅ |
+| | `set_vt_multi` | Update visibility timeouts across multiple queues | ✅ |
 | | `list_queues` | List all queues with metadata | ✅ |
 | | `metrics` | Get queue metrics (length, age, total messages) | ✅ |
 | | `metrics_all` | Get metrics for all queues | ✅ |
@@ -377,6 +379,15 @@ archived_ids = client.archive_batch("queue_name", [101, 102, 103])
 
 # Update visibility timeout
 msg = client.set_vt("queue_name", msg_id, vt_offset: 60)
+
+# Batch update visibility timeout
+updated_msgs = client.set_vt_batch("queue_name", [101, 102, 103], vt_offset: 60)
+
+# Update visibility timeout across multiple queues
+client.set_vt_multi({
+  "orders" => [1, 2, 3],
+  "notifications" => [5, 6]
+}, vt_offset: 120)
 
 # Purge all messages
 count = client.purge_queue("queue_name")


### PR DESCRIPTION
## Summary

Implements batch visibility timeout updates following the pattern established by `delete_batch`/`delete_multi` and `archive_batch`/`archive_multi`.

This mirrors the Rust PGMQ client's batch `set_vt` support ([PR #452](https://github.com/tembo-io/pgmq/pull/452)).

## New Methods

### `set_vt_batch(queue_name, msg_ids, vt_offset:)`
Update visibility timeout for multiple messages in a single queue.

```ruby
# Extend processing time for multiple messages
updated_msgs = client.set_vt_batch("orders", [101, 102, 103], vt_offset: 60)
```

### `set_vt_multi(updates_hash, vt_offset:)`
Update visibility timeouts across multiple queues atomically within a transaction.

```ruby
# Extend timeout after batch reading from multiple queues
messages = client.read_multi(['q1', 'q2', 'q3'], qty: 10)
updates = messages.group_by(&:queue_name).transform_values { |msgs| msgs.map(&:msg_id) }
client.set_vt_multi(updates, vt_offset: 120)
```

## Use Cases

- Extending processing time for a batch of messages being processed together
- Coordinating visibility timeout updates across related messages in different queues
- Heartbeat patterns where workers periodically extend VT for all messages they're processing

## Implementation Notes

- Uses the existing `pgmq.set_vt(queue_name, msg_ids[], vt)` SQL function (already available in PGMQ extension)
- `set_vt_multi` wraps operations in a transaction for atomicity
- Follows the same patterns as existing batch/multi methods

## Test plan

- [x] `set_vt_batch` updates visibility timeout for multiple messages
- [x] `set_vt_batch` handles empty array
- [x] `set_vt_batch` returns empty array for non-existent messages
- [x] `set_vt_multi` updates visibility timeout across multiple queues
- [x] `set_vt_multi` returns empty hash for empty input
- [x] `set_vt_multi` raises ArgumentError for non-hash input
- [x] `set_vt_multi` skips queues with empty message arrays
- [x] All 196 tests pass with 96.78% coverage