### PR TITLE
Add pop_batch for atomic batch read + delete operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0 (Unreleased)
 
 ### Message Operations
+- **[Feature]** Introduce `pop_batch(queue_name, qty)` for atomic batch pop (read + delete) operations.
 - **[Feature]** Introduce `set_vt_batch(queue_name, msg_ids, vt_offset:)` for batch visibility timeout updates.
 - **[Feature]** Introduce `set_vt_multi(updates_hash, vt_offset:)` for updating visibility timeouts across multiple queues atomically.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | | `read_batch` | Read multiple messages with visibility timeout | ✅ |
 | | `read_with_poll` | Long-polling for efficient message consumption | ✅ |
 | | `pop` | Atomic read + delete operation | ✅ |
+| | `pop_batch` | Atomic batch read + delete operation | ✅ |
 | **Deleting/Archiving** | `delete` | Delete single message | ✅ |
 | | `delete_batch` | Delete multiple messages | ✅ |
 | | `archive` | Archive single message for long-term storage | ✅ |
@@ -313,6 +314,9 @@ msg = client.read_with_poll("queue_name",
 
 # Pop (atomic read + delete)
 msg = client.pop("queue_name")
+
+# Pop batch (atomic read + delete for multiple messages)
+messages = client.pop_batch("queue_name", 10)
 ```
 
 #### Conditional Message Filtering


### PR DESCRIPTION
## Summary

Adds `pop_batch(queue_name, qty)` method for atomically popping multiple messages from a queue in a single operation.

This mirrors the PGMQ extension's `pgmq.pop(queue_name, qty)` function added in [PR #433](https://github.com/tembo-io/pgmq/pull/433).

## New Method

### `pop_batch(queue_name, qty)`

Atomically reads and deletes multiple messages from a queue.

```ruby
# Pop up to 10 messages atomically
messages = client.pop_batch("orders", 10)
messages.each { |msg| process(msg.payload) }
# No need to delete - messages are already removed from queue
```

## Pattern Consistency

This follows the established pattern of other batch operations:

| Single | Batch |
|--------|-------|
| `read` | `read_batch` |
| `delete` | `delete_batch` |
| `archive` | `archive_batch` |
| `set_vt` | `set_vt_batch` |
| `pop` | **`pop_batch`** ← new |

## Use Cases

- High-throughput consumers that can process multiple messages at once
- Batch processing where messages are handled as a group
- Reducing database round-trips for pop operations

## Test plan

- [x] `pop_batch` pops multiple messages atomically
- [x] `pop_batch` returns only available messages when qty exceeds queue size
- [x] `pop_batch` returns empty array for empty queue
- [x] `pop_batch` returns empty array when qty is zero
- [x] `pop_batch` raises error for invalid queue name
- [x] All 194 tests pass with 96.67% coverage