### PR TITLE
Rename send/send_batch to produce/produce_batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## 0.4.0 (Unreleased)
 
+### Breaking Changes
+- **[Breaking]** Rename `send` to `produce` and `send_batch` to `produce_batch`. This avoids shadowing Ruby's built-in `Object#send` method which caused confusion and required workarounds (e.g., using `__send__`). The new names also align better with the producer/consumer terminology used in message queue systems.
+
 ### Queue Management
 - [Enhancement] `create`, `create_partitioned`, and `create_unlogged` now return `true` if the queue was newly created, `false` if it already existed. This provides clearer feedback and aligns with the Rust PGMQ client behavior.
 
 ### Message Operations
-- **[Feature]** Add `headers:` parameter to `send(queue_name, message, headers:, delay:)` for message metadata (routing, tracing, correlation IDs).
-- **[Feature]** Add `headers:` parameter to `send_batch(queue_name, messages, headers:, delay:)` for batch message metadata.
+- **[Feature]** Add `headers:` parameter to `produce(queue_name, message, headers:, delay:)` for message metadata (routing, tracing, correlation IDs).
+- **[Feature]** Add `headers:` parameter to `produce_batch(queue_name, messages, headers:, delay:)` for batch message metadata.
 - **[Feature]** Introduce `pop_batch(queue_name, qty)` for atomic batch pop (read + delete) operations.
 - **[Feature]** Introduce `set_vt_batch(queue_name, msg_ids, vt_offset:)` for batch visibility timeout updates.
 - **[Feature]** Introduce `set_vt_multi(updates_hash, vt_offset:)` for updating visibility timeouts across multiple queues atomically.

--- a/lib/pgmq.rb
+++ b/lib/pgmq.rb
@@ -33,7 +33,7 @@ loader.eager_load
 #
 #   # Basic queue operations
 #   client.create('orders')
-#   msg_id = client.send('orders', { order_id: 123 })
+#   msg_id = client.produce('orders', '{"order_id":123}')
 #   msg = client.read('orders', vt: 30)
 #   client.delete('orders', msg.msg_id)
 #   client.drop_queue('orders')

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -14,7 +14,7 @@ module PGMQ
   #     password: 'postgres'
   #   )
   #   client.create('my_queue')
-  #   msg_id = client.send('my_queue', { data: 'value' })
+  #   msg_id = client.produce('my_queue', '{"data":"value"}')
   #   msg = client.read('my_queue', vt: 30)
   #   client.delete('my_queue', msg.msg_id)
   #
@@ -27,7 +27,7 @@ module PGMQ
     # Include functional modules (order matters for discoverability)
     include Transaction          # Transaction support (already existed)
     include QueueManagement      # Queue lifecycle (create, drop, list)
-    include Producer             # Message sending operations
+    include Producer             # Message producing operations
     include Consumer             # Single-queue reading operations
     include MultiQueue           # Multi-queue operations
     include MessageLifecycle     # Message state transitions (pop, delete, archive)

--- a/lib/pgmq/client/producer.rb
+++ b/lib/pgmq/client/producer.rb
@@ -2,12 +2,12 @@
 
 module PGMQ
   class Client
-    # Message sending operations
+    # Message producing operations
     #
-    # This module handles sending messages to queues, both individual messages
+    # This module handles producing messages to queues, both individual messages
     # and batches. Users must serialize messages to JSON strings themselves.
     module Producer
-      # Sends a message to a queue
+      # Produces a message to a queue
       #
       # @param queue_name [String] name of the queue
       # @param message [String] message as JSON string (for PostgreSQL JSONB)
@@ -15,24 +15,24 @@ module PGMQ
       # @param delay [Integer] delay in seconds before message becomes visible
       # @return [String] message ID as string
       #
-      # @example Basic send
-      #   msg_id = client.send("orders", '{"order_id":123,"total":99.99}')
+      # @example Basic produce
+      #   msg_id = client.produce("orders", '{"order_id":123,"total":99.99}')
       #
       # @example With delay
-      #   msg_id = client.send("orders", '{"data":"value"}', delay: 60)
+      #   msg_id = client.produce("orders", '{"data":"value"}', delay: 60)
       #
       # @example With headers for routing/tracing
-      #   msg_id = client.send("orders", '{"order_id":123}',
+      #   msg_id = client.produce("orders", '{"order_id":123}',
       #     headers: '{"trace_id":"abc123","priority":"high"}')
       #
       # @example With headers and delay
-      #   msg_id = client.send("orders", '{"order_id":123}',
+      #   msg_id = client.produce("orders", '{"order_id":123}',
       #     headers: '{"correlation_id":"req-456"}',
       #     delay: 30)
       #
       # @note Users must serialize to JSON themselves. Higher-level frameworks
       #       should handle serialization.
-      def send(
+      def produce(
         queue_name,
         message,
         headers: nil,
@@ -57,7 +57,7 @@ module PGMQ
         result[0]['send']
       end
 
-      # Sends multiple messages to a queue in a batch
+      # Produces multiple messages to a queue in a batch
       #
       # @param queue_name [String] name of the queue
       # @param messages [Array<String>] array of message payloads as JSON strings
@@ -66,24 +66,24 @@ module PGMQ
       # @return [Array<String>] array of message IDs
       # @raise [ArgumentError] if headers array length doesn't match messages length
       #
-      # @example Basic batch send
-      #   ids = client.send_batch("orders", [
+      # @example Basic batch produce
+      #   ids = client.produce_batch("orders", [
       #     '{"order_id":1}',
       #     '{"order_id":2}',
       #     '{"order_id":3}'
       #   ])
       #
       # @example With headers (one per message)
-      #   ids = client.send_batch("orders",
+      #   ids = client.produce_batch("orders",
       #     ['{"order_id":1}', '{"order_id":2}'],
       #     headers: ['{"priority":"high"}', '{"priority":"low"}'])
       #
       # @example With headers and delay
-      #   ids = client.send_batch("orders",
+      #   ids = client.produce_batch("orders",
       #     ['{"order_id":1}', '{"order_id":2}'],
       #     headers: ['{"trace_id":"a"}', '{"trace_id":"b"}'],
       #     delay: 60)
-      def send_batch(
+      def produce_batch(
         queue_name,
         messages,
         headers: nil,

--- a/lib/pgmq/transaction.rb
+++ b/lib/pgmq/transaction.rb
@@ -12,13 +12,13 @@ module PGMQ
   #
   # @example Atomic multi-queue operations
   #   client.transaction do |txn|
-  #     txn.send("orders", { order_id: 123 })
-  #     txn.send("notifications", { type: "order_created" })
+  #     txn.produce("orders", '{"order_id":123}')
+  #     txn.produce("notifications", '{"type":"order_created"}')
   #   end
   #
   # @example Automatic rollback on error
   #   client.transaction do |txn|
-  #     txn.send("orders", { order_id: 123 })
+  #     txn.produce("orders", '{"order_id":123}')
   #     raise "Error"  # Both operations rolled back
   #   end
   module Transaction
@@ -33,7 +33,7 @@ module PGMQ
     #
     # @example
     #   client.transaction do |txn|
-    #     msg_id = txn.send("queue", { data: "test" })
+    #     msg_id = txn.produce("queue", '{"data":"test"}')
     #     txn.delete("queue", msg_id)
     #   end
     def transaction
@@ -65,19 +65,6 @@ module PGMQ
       # @return [Object] result of method call
       def method_missing(method, ...)
         @parent.respond_to?(method, true) ? @parent.__send__(method, ...) : super
-      end
-
-      # Override Object#send to call parent's send method
-      # @param queue_name [String] queue name
-      # @param message [String] message as JSON string
-      # @param delay [Integer] delay in seconds
-      # @return [String] message ID
-      def send(
-        queue_name,
-        message,
-        delay: 0
-      )
-        @parent.send(queue_name, message, delay: delay)
       end
 
       # Check if method exists on parent

--- a/spec/lib/pgmq/client/maintenance_spec.rb
+++ b/spec/lib/pgmq/client/maintenance_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PGMQ::Client::Maintenance, :integration do
   describe '#purge_queue' do
     it 'purges all messages from queue' do
       batch = [to_json_msg({ a: 1 }), to_json_msg({ b: 2 }), to_json_msg({ c: 3 })]
-      client.send_batch(queue_name, batch)
+      client.produce_batch(queue_name, batch)
 
       count = client.purge_queue(queue_name)
       expect(count).to eq('3')
@@ -36,14 +36,14 @@ RSpec.describe PGMQ::Client::Maintenance, :integration do
   describe '#detach_archive' do
     it 'detaches archive table from queue management' do
       # Send and archive a message first
-      msg_id = client.send(queue_name, to_json_msg({ test: 'archive' }))
+      msg_id = client.produce(queue_name, to_json_msg({ test: 'archive' }))
       client.archive(queue_name, msg_id)
 
       # Detach the archive
       client.detach_archive(queue_name)
 
       # Queue should still exist and be usable
-      new_msg_id = client.send(queue_name, to_json_msg({ test: 'after_detach' }))
+      new_msg_id = client.produce(queue_name, to_json_msg({ test: 'after_detach' }))
       msg = client.read(queue_name, vt: 30)
       expect(msg.msg_id).to eq(new_msg_id)
     end

--- a/spec/lib/pgmq/client/metrics_spec.rb
+++ b/spec/lib/pgmq/client/metrics_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PGMQ::Client::Metrics, :integration do
     it 'returns queue metrics' do
       # Send some messages
       batch = [to_json_msg({ a: 1 }), to_json_msg({ b: 2 }), to_json_msg({ c: 3 })]
-      client.send_batch(queue_name, batch)
+      client.produce_batch(queue_name, batch)
 
       metrics = client.metrics(queue_name)
       expect(metrics).to be_a(PGMQ::Metrics)
@@ -49,8 +49,8 @@ RSpec.describe PGMQ::Client::Metrics, :integration do
 
       client.create(queue1)
       client.create(queue2)
-      client.send(queue1, to_json_msg({ test: 1 }))
-      client.send(queue2, to_json_msg({ test: 2 }))
+      client.produce(queue1, to_json_msg({ test: 1 }))
+      client.produce(queue2, to_json_msg({ test: 2 }))
 
       all_metrics = client.metrics_all
       expect(all_metrics).to be_an(Array)

--- a/spec/lib/pgmq/client/multi_queue_spec.rb
+++ b/spec/lib/pgmq/client/multi_queue_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
   describe 'single connection, single query' do
     it 'reads from multiple queues in one query' do
       # Send to different queues
-      client.send(queue1, to_json_msg({ from: 'q1' }))
-      client.send(queue2, to_json_msg({ from: 'q2' }))
-      client.send(queue3, to_json_msg({ from: 'q3' }))
+      client.produce(queue1, to_json_msg({ from: 'q1' }))
+      client.produce(queue2, to_json_msg({ from: 'q2' }))
+      client.produce(queue3, to_json_msg({ from: 'q3' }))
 
       messages = client.read_multi([queue1, queue2, queue3], vt: 30)
 
@@ -34,7 +34,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'returns messages with queue_name attribute' do
-      client.send(queue1, to_json_msg({ data: 'test' }))
+      client.produce(queue1, to_json_msg({ data: 'test' }))
 
       messages = client.read_multi([queue1, queue2], vt: 30)
 
@@ -44,8 +44,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'respects limit parameter' do
-      5.times { client.send(queue1, to_json_msg({ n: 1 })) }
-      5.times { client.send(queue2, to_json_msg({ n: 2 })) }
+      5.times { client.produce(queue1, to_json_msg({ n: 1 })) }
+      5.times { client.produce(queue2, to_json_msg({ n: 2 })) }
 
       messages = client.read_multi([queue1, queue2], vt: 30, qty: 5, limit: 3)
 
@@ -53,8 +53,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'respects qty per queue' do
-      10.times { client.send(queue1, to_json_msg({ n: 1 })) }
-      10.times { client.send(queue2, to_json_msg({ n: 2 })) }
+      10.times { client.produce(queue1, to_json_msg({ n: 1 })) }
+      10.times { client.produce(queue2, to_json_msg({ n: 2 })) }
 
       messages = client.read_multi([queue1, queue2], vt: 30, qty: 2)
 
@@ -74,7 +74,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
     it 'gets first available message from any queue with limit 1' do
       # Only send to queue2
-      client.send(queue2, to_json_msg({ from: 'q2' }))
+      client.produce(queue2, to_json_msg({ from: 'q2' }))
 
       messages = client.read_multi([queue1, queue2, queue3], vt: 30, limit: 1)
 
@@ -114,9 +114,9 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
   describe 'practical use cases' do
     it 'supports round-robin processing' do
       # Simulate worker pattern: process first available from multiple queues
-      client.send(queue1, to_json_msg({ job: 'email' }))
-      client.send(queue2, to_json_msg({ job: 'notification' }))
-      client.send(queue3, to_json_msg({ job: 'webhook' }))
+      client.produce(queue1, to_json_msg({ job: 'email' }))
+      client.produce(queue2, to_json_msg({ job: 'notification' }))
+      client.produce(queue3, to_json_msg({ job: 'webhook' }))
 
       processed = []
       3.times do
@@ -134,9 +134,9 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
     it 'supports batch processing across queues' do
       # Send multiple to each queue
-      5.times { client.send(queue1, to_json_msg({ type: 'order' })) }
-      5.times { client.send(queue2, to_json_msg({ type: 'email' })) }
-      5.times { client.send(queue3, to_json_msg({ type: 'sms' })) }
+      5.times { client.produce(queue1, to_json_msg({ type: 'order' })) }
+      5.times { client.produce(queue2, to_json_msg({ type: 'email' })) }
+      5.times { client.produce(queue3, to_json_msg({ type: 'sms' })) }
 
       # Get messages from all queues
       messages = client.read_multi([queue1, queue2, queue3], vt: 1, qty: 2, limit: 5)
@@ -179,7 +179,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
       # Send message after short delay
       sleep 0.5
-      client.send(queue2, to_json_msg({ delayed: true }))
+      client.produce(queue2, to_json_msg({ delayed: true }))
 
       thread.join
       expect(result.size).to eq(1)
@@ -187,7 +187,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'returns immediately if messages exist' do
-      client.send(queue1, to_json_msg({ immediate: true }))
+      client.produce(queue1, to_json_msg({ immediate: true }))
 
       start = Time.now
       messages = client.read_multi_with_poll(
@@ -217,8 +217,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'respects qty and limit parameters' do
-      5.times { client.send(queue1, to_json_msg({ n: 1 })) }
-      5.times { client.send(queue2, to_json_msg({ n: 2 })) }
+      5.times { client.produce(queue1, to_json_msg({ n: 1 })) }
+      5.times { client.produce(queue2, to_json_msg({ n: 2 })) }
 
       messages = client.read_multi_with_poll(
         [queue1, queue2, queue3],
@@ -245,7 +245,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
     it 'gets first available from any queue' do
       # Only queue3 has messages
-      client.send(queue3, to_json_msg({ only_in_q3: true }))
+      client.produce(queue3, to_json_msg({ only_in_q3: true }))
 
       messages = client.read_multi_with_poll(
         [queue1, queue2, queue3],
@@ -261,7 +261,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
   describe '#pop_multi' do
     it 'pops and deletes from first available queue' do
-      client.send(queue2, to_json_msg({ data: 'test' }))
+      client.produce(queue2, to_json_msg({ data: 'test' }))
 
       msg = client.pop_multi([queue1, queue2, queue3])
 
@@ -281,7 +281,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
     it 'pops from first non-empty queue' do
       # Send to queue3 only
-      client.send(queue3, to_json_msg({ from: 'q3' }))
+      client.produce(queue3, to_json_msg({ from: 'q3' }))
 
       msg = client.pop_multi([queue1, queue2, queue3])
 
@@ -314,7 +314,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'has queue_name attribute on returned message' do
-      client.send(queue1, to_json_msg({ test: 'data' }))
+      client.produce(queue1, to_json_msg({ test: 'data' }))
       msg = client.pop_multi([queue1, queue2])
 
       expect(msg).to respond_to(:queue_name)
@@ -325,9 +325,9 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
   describe '#delete_multi' do
     it 'deletes messages from multiple queues' do
       # Send messages
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
-      id2 = client.send(queue1, to_json_msg({ n: 2 }))
-      id3 = client.send(queue2, to_json_msg({ n: 3 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
+      id2 = client.produce(queue1, to_json_msg({ n: 2 }))
+      id3 = client.produce(queue2, to_json_msg({ n: 3 }))
 
       result = client.delete_multi({
         queue1 => [id1, id2],
@@ -348,7 +348,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'skips empty message ID arrays' do
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
 
       result = client.delete_multi({
         queue1 => [id1],
@@ -372,8 +372,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'is transactional (all or nothing)' do
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
-      id2 = client.send(queue2, to_json_msg({ n: 2 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
+      id2 = client.produce(queue2, to_json_msg({ n: 2 }))
 
       # This should work atomically
       result = client.delete_multi({
@@ -385,8 +385,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'works with batch processing pattern' do
-      5.times { client.send(queue1, to_json_msg({ q: 1 })) }
-      5.times { client.send(queue2, to_json_msg({ q: 2 })) }
+      5.times { client.produce(queue1, to_json_msg({ q: 1 })) }
+      5.times { client.produce(queue2, to_json_msg({ q: 2 })) }
 
       messages = client.read_multi([queue1, queue2], vt: 30, qty: 10)
       deletions = messages.group_by(&:queue_name).transform_values { |msgs| msgs.map(&:msg_id) }
@@ -399,8 +399,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
 
   describe '#archive_multi' do
     it 'archives messages from multiple queues' do
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
-      id2 = client.send(queue2, to_json_msg({ n: 2 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
+      id2 = client.produce(queue2, to_json_msg({ n: 2 }))
 
       result = client.archive_multi({
         queue1 => [id1],
@@ -421,7 +421,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'skips empty message ID arrays' do
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
 
       result = client.archive_multi({
         queue1 => [id1],
@@ -445,8 +445,8 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'is transactional' do
-      id1 = client.send(queue1, to_json_msg({ n: 1 }))
-      id2 = client.send(queue2, to_json_msg({ n: 2 }))
+      id1 = client.produce(queue1, to_json_msg({ n: 1 }))
+      id2 = client.produce(queue2, to_json_msg({ n: 2 }))
 
       result = client.archive_multi({
         queue1 => [id1],
@@ -457,7 +457,7 @@ RSpec.describe PGMQ::Client::MultiQueue, :integration do
     end
 
     it 'archives multiple messages from same queue' do
-      ids = Array.new(3) { client.send(queue1, to_json_msg({ n: 1 })) }
+      ids = Array.new(3) { client.produce(queue1, to_json_msg({ n: 1 })) }
 
       result = client.archive_multi({
         queue1 => ids

--- a/spec/lib/pgmq/client/queue_management_spec.rb
+++ b/spec/lib/pgmq/client/queue_management_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe PGMQ::Client::QueueManagement, :integration do
       expect(queues.map(&:queue_name)).to include(queue_name)
 
       # Verify it works by sending/reading a message
-      msg_id = client.send(queue_name, to_json_msg({ test: 'unlogged' }))
+      msg_id = client.produce(queue_name, to_json_msg({ test: 'unlogged' }))
       msg = client.read(queue_name, vt: 30)
       expect(msg.msg_id).to eq(msg_id)
       expect(JSON.parse(msg.message)['test']).to eq('unlogged')

--- a/spec/lib/pgmq/connection_spec.rb
+++ b/spec/lib/pgmq/connection_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe PGMQ::Connection do
 
       threads = Array.new(10) do |i|
         Thread.new do
-          client.send(queue, to_json_msg({ thread: i }))
+          client.produce(queue, to_json_msg({ thread: i }))
         end
       end
 
@@ -176,7 +176,7 @@ RSpec.describe PGMQ::Connection do
 
       5.times do |i|
         fibers << Fiber.new do
-          client.send(queue, to_json_msg({ fiber: i }))
+          client.produce(queue, to_json_msg({ fiber: i }))
           results << i
           Fiber.yield
         end


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: Rename `send` to `produce` and `send_batch` to `produce_batch`
- Avoids shadowing Ruby's built-in `Object#send` method which caused confusion and required workarounds (e.g., using `__send__`)
- New names align with producer/consumer terminology used in message queue systems like Kafka

## Changes
- Renamed methods in `lib/pgmq/client/producer.rb`
- Updated all documentation comments
- Updated all tests
- Removed `TransactionalClient#send` override (no longer needed since `method_missing` now handles `produce` correctly)
- Updated CHANGELOG.md with breaking change notice
- Updated README.md with new method names

## Test plan
- [x] All 225 tests pass
- [x] Coverage at 97.01% (above 96.50% threshold)
- [x] yard-lint passes