### PR TITLE
Add examples directory with 14 executable example scripts

### DIFF
--- a/.coditsu.yml
+++ b/.coditsu.yml
@@ -1,5 +1,0 @@
----
-# Exclude examples/ which is a symlink to spec/integration/
-# Coditsu has issues with git blame on symlinked paths
-excluded_paths:
-  - examples/

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,8 @@ require 'bundler/gem_tasks'
 namespace :examples do
   desc 'Run all examples (validates gem functionality)'
   task :run do
-    examples_dir = File.expand_path('examples', __dir__)
-    example_files = Dir.glob(File.join(examples_dir, '*.rb'))
-                       .select { |f| File.basename(f) =~ /^\d{2}_/ }
-                       .sort
+    examples_dir = File.expand_path('spec/integration', __dir__)
+    example_files = Dir.glob(File.join(examples_dir, '*_spec.rb')).sort
 
     puts "Running #{example_files.size} examples..."
     puts
@@ -20,7 +18,10 @@ namespace :examples do
       puts "[#{index + 1}/#{example_files.size}] Running #{name}..."
 
       success = system("bundle exec ruby #{example}")
-      unless success
+      if success.nil?
+        puts 'Interrupted. Aborting.'
+        exit(130)
+      elsif !success
         failed << name
         puts "FAILED: #{name}"
       end
@@ -37,14 +38,14 @@ namespace :examples do
     end
   end
 
-  desc 'Run a specific example by number (e.g., rake examples:run_one[01])'
-  task :run_one, [:number] do |_t, args|
-    examples_dir = File.expand_path('examples', __dir__)
-    pattern = File.join(examples_dir, "#{args[:number]}_*.rb")
+  desc 'Run a specific example by name (e.g., rake examples:run_one[basic_produce_consume])'
+  task :run_one, [:name] do |_t, args|
+    examples_dir = File.expand_path('spec/integration', __dir__)
+    pattern = File.join(examples_dir, "*#{args[:name]}*_spec.rb")
     matches = Dir.glob(pattern)
 
     if matches.empty?
-      puts "No example found matching: #{args[:number]}"
+      puts "No example found matching: #{args[:name]}"
       exit(1)
     end
 
@@ -53,19 +54,17 @@ namespace :examples do
 
   desc 'List all available examples'
   task :list do
-    examples_dir = File.expand_path('examples', __dir__)
-    example_files = Dir.glob(File.join(examples_dir, '*.rb'))
-                       .select { |f| File.basename(f) =~ /^\d{2}_/ }
-                       .sort
+    examples_dir = File.expand_path('spec/integration', __dir__)
+    example_files = Dir.glob(File.join(examples_dir, '*_spec.rb')).sort
 
     puts 'Available examples:'
     example_files.each do |f|
-      name = File.basename(f, '.rb')
+      name = File.basename(f, '_spec.rb')
       puts "  #{name}"
     end
     puts
-    puts 'Run with: bundle exec rake examples:run_one[NUMBER]'
-    puts 'Example:  bundle exec rake examples:run_one[01]'
+    puts 'Run with: bundle exec rake examples:run_one[NAME]'
+    puts 'Example:  bundle exec rake examples:run_one[basic_produce_consume]'
   end
 end
 

--- a/examples
+++ b/examples
@@ -1,1 +1,0 @@
-spec/integration

--- a/spec/integration/archiving_spec.rb
+++ b/spec/integration/archiving_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Message Archiving
@@ -7,7 +6,7 @@
 # - delete: Permanently removes message
 # - archive: Moves to archive table for audit/analysis
 #
-# Run: bundle exec ruby examples/08_archiving_spec.rb
+# Run: bundle exec ruby spec/integration/archiving_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/basic_produce_consume_spec.rb
+++ b/spec/integration/basic_produce_consume_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Basic Produce and Consume
@@ -9,7 +8,7 @@
 # 3. Read the message with visibility timeout
 # 4. Delete the message after processing
 #
-# Run: bundle exec ruby examples/01_basic_produce_consume_spec.rb
+# Run: bundle exec ruby spec/integration/basic_produce_consume_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/batch_operations_spec.rb
+++ b/spec/integration/batch_operations_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Batch Operations
@@ -8,7 +7,7 @@
 # - read_batch: Read multiple messages at once
 # - delete_batch: Delete multiple messages efficiently
 #
-# Run: bundle exec ruby examples/02_batch_operations_spec.rb
+# Run: bundle exec ruby spec/integration/batch_operations_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/conditional_filtering_spec.rb
+++ b/spec/integration/conditional_filtering_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Conditional Filtering
@@ -8,7 +7,7 @@
 # - Multiple conditions use AND logic
 # - Works with read, read_batch, and read_with_poll
 #
-# Run: bundle exec ruby examples/07_conditional_filtering_spec.rb
+# Run: bundle exec ruby spec/integration/conditional_filtering_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/delayed_messages_spec.rb
+++ b/spec/integration/delayed_messages_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Delayed Messages
@@ -7,7 +6,7 @@
 # - produce with delay: Message invisible until delay expires
 # - Use cases: scheduled tasks, retry backoff, rate limiting
 #
-# Run: bundle exec ruby examples/10_delayed_messages_spec.rb
+# Run: bundle exec ruby spec/integration/delayed_messages_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Error Handling
@@ -8,7 +7,7 @@
 # - Dead letter queue (DLQ) pattern
 # - Retry with max attempts
 #
-# Run: bundle exec ruby examples/14_error_handling_spec.rb
+# Run: bundle exec ruby spec/integration/error_handling_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/long_polling_spec.rb
+++ b/spec/integration/long_polling_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Long Polling
@@ -7,7 +6,7 @@
 # - read_with_poll blocks until a message arrives or timeout expires
 # - More efficient than busy-waiting with repeated read calls
 #
-# Run: bundle exec ruby examples/03_long_polling_spec.rb
+# Run: bundle exec ruby spec/integration/long_polling_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/message_headers_spec.rb
+++ b/spec/integration/message_headers_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Message Headers
@@ -7,7 +6,7 @@
 # - Headers are stored separately from payload
 # - Useful for tracing, routing, priority handling
 #
-# Run: bundle exec ruby examples/11_message_headers_spec.rb
+# Run: bundle exec ruby spec/integration/message_headers_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/multi_queue_spec.rb
+++ b/spec/integration/multi_queue_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Multi-Queue Operations
@@ -8,7 +7,7 @@
 # - read_multi_with_poll: Long-poll across multiple queues
 # - pop_multi: Atomic read+delete from first available queue
 #
-# Run: bundle exec ruby examples/04_multi_queue_spec.rb
+# Run: bundle exec ruby spec/integration/multi_queue_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/pop_pattern_spec.rb
+++ b/spec/integration/pop_pattern_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Pop Pattern (Atomic Read + Delete)
@@ -8,7 +7,7 @@
 # - pop_batch: Atomic batch read+delete
 # - No VT needed - message is immediately deleted
 #
-# Run: bundle exec ruby examples/13_pop_pattern_spec.rb
+# Run: bundle exec ruby spec/integration/pop_pattern_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/queue_metrics_spec.rb
+++ b/spec/integration/queue_metrics_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Queue Metrics and Monitoring
@@ -8,7 +7,7 @@
 # - metrics_all: Get metrics for all queues
 # - list_queues: List all queues with metadata
 #
-# Run: bundle exec ruby examples/09_queue_metrics_spec.rb
+# Run: bundle exec ruby spec/integration/queue_metrics_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/queue_types_spec.rb
+++ b/spec/integration/queue_types_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Queue Types
@@ -8,7 +7,7 @@
 # - Unlogged (create_unlogged): Fast, no WAL, not crash-safe
 # - Partitioned (create_partitioned): For high-volume queues
 #
-# Run: bundle exec ruby examples/12_queue_types_spec.rb
+# Run: bundle exec ruby spec/integration/queue_types_spec.rb
 
 require_relative 'support/example_helper'
 

--- a/spec/integration/support/example_helper.rb
+++ b/spec/integration/support/example_helper.rb
@@ -69,7 +69,11 @@ module ExampleHelper
         exit(1)
       ensure
         # Restore original signal handler
-        Signal.trap('INT', original_handler || 'DEFAULT')
+        case original_handler
+        when String then Signal.trap('INT', original_handler)
+        when Proc then Signal.trap('INT', &original_handler)
+        else Signal.trap('INT', 'DEFAULT')
+        end
         cleanup(client, queues)
         client.close
       end

--- a/spec/integration/transactions_spec.rb
+++ b/spec/integration/transactions_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Transactions
@@ -8,7 +7,7 @@
 # - Automatic rollback on errors
 # - Essential for read-process-forward patterns
 #
-# Run: bundle exec ruby examples/05_transactions_spec.rb
+# Run: bundle exec ruby spec/integration/transactions_spec.rb
 
 require_relative 'support/example_helper'
 
@@ -52,6 +51,7 @@ ExampleHelper.run_example('Transactions') do |client, queues, interrupted|
   # Verify rollback (message still in inbox)
   msg = client.read(inbox, vt: 1)
   puts "Message still in inbox after rollback: #{!msg.nil?}"
+  # Make message immediately visible again (negative offset moves VT back in time)
   client.set_vt(inbox, msg.msg_id, vt_offset: -30) if msg
 
   # Clean up

--- a/spec/integration/visibility_timeout_spec.rb
+++ b/spec/integration/visibility_timeout_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Example: Visibility Timeout Management
@@ -7,7 +6,7 @@
 # - set_vt: Extend visibility timeout for a message
 # - Heartbeat pattern: Periodically extend VT during long processing
 #
-# Run: bundle exec ruby examples/06_visibility_timeout_spec.rb
+# Run: bundle exec ruby spec/integration/visibility_timeout_spec.rb
 
 require_relative 'support/example_helper'
 


### PR DESCRIPTION
## Summary

This PR adds a `spec/integration/` directory with 14 self-contained Ruby scripts demonstrating all major PGMQ-Ruby capabilities. Each example serves as both documentation for users and integration tests for CI.

### Examples included:

| File | Purpose | Key API |
|------|---------|---------|
| basic_produce_consume_spec.rb | Fundamental workflow | `create`, `produce`, `read`, `delete` |
| batch_operations_spec.rb | High-throughput batch ops | `produce_batch`, `read_batch`, `delete_batch` |
| long_polling_spec.rb | Efficient blocking reads | `read_with_poll` |
| multi_queue_spec.rb | Reading from multiple queues | `read_multi`, `read_multi_with_poll`, `pop_multi` |
| transactions_spec.rb | Atomic cross-queue operations | `transaction { \|txn\| ... }` |
| visibility_timeout_spec.rb | Extending processing time | `set_vt`, `set_vt_batch` |
| conditional_filtering_spec.rb | Server-side JSONB filtering | `read` with `conditional:` |
| archiving_spec.rb | Audit trail patterns | `archive`, `archive_batch`, `detach_archive` |
| queue_metrics_spec.rb | Monitoring capabilities | `metrics`, `metrics_all` |
| delayed_messages_spec.rb | Scheduled delivery | `produce` with `delay:` |
| message_headers_spec.rb | Metadata/routing | `produce` with `headers:` |
| queue_types_spec.rb | Different queue types | `create_unlogged`, `create_partitioned` |
| pop_pattern_spec.rb | Atomic read+delete | `pop`, `pop_batch` |
| error_handling_spec.rb | Error patterns | `PGMQ::Errors::*` hierarchy, DLQ pattern |

### Features:

- Each example is executable via `bundle exec ruby spec/integration/NAME_spec.rb`
- Handles SIGINT (Ctrl+C) gracefully for clean interruption
- Cleans up resources (queues) automatically after execution
- Uses unique queue names to avoid conflicts in parallel runs
- Plain output format (no colors/emojis)

### CI/CD Integration:

- Added Rake tasks: `bundle exec rake examples` (run all) and `bundle exec rake examples:run_one[basic_produce_consume]` (run specific)
- Added CI step to run examples after tests in all matrix configurations
- Examples validate gem functionality as part of the test suite
- RSpec configured to exclude `spec/integration/` (these are not RSpec tests)

## Test plan

- [x] All 14 examples run successfully locally
- [x] Examples pass with `bundle exec rake examples`
- [x] RSpec does not pick up integration examples
- [x] CI passes on all Ruby/PostgreSQL matrix configurations