### PR TITLE
Extract linting tools to separate Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      BUNDLE_GEMFILE: Gemfile.lint
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
-      - name: Remove Gemfile.lock for Ruby 4.0
-        run: rm -f Gemfile.lock
       - name: Set up Ruby
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 group :development, :test do
   gem 'rake'
   gem 'rspec'
-  gem 'yard-lint'
 end
 
 group :test do

--- a/Gemfile.lint
+++ b/Gemfile.lint
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Documentation linting
+gem 'yard-lint'

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    yard (0.9.38)
+    yard-lint (1.4.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.6)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  yard-lint
+
+CHECKSUMS
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    yard (0.9.38)
-    yard-lint (1.3.0)
-      yard (~> 0.9)
-      zeitwerk (~> 2.6)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -59,7 +55,6 @@ DEPENDENCIES
   rake
   rspec
   simplecov
-  yard-lint
 
 BUNDLED WITH
    2.7.2

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "config:recommended"
   ],
+  "includePaths": [
+    "Gemfile",
+    "Gemfile.lint",
+    ".github/workflows/**"
+  ],
   "minimumReleaseAge": "7 days",
   "github-actions": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Move `yard-lint` to a separate `Gemfile.lint` to isolate non-execution/linting dependencies
- Update CI to use `BUNDLE_GEMFILE=Gemfile.lint` for the yard-lint job
- Remove Gemfile.lock deletion step (no longer needed with separate Gemfile)
- Add `Gemfile.lint` to Renovate's `includePaths` for automatic dependency updates

## Test plan

- [ ] Verify yard-lint CI job passes with the separate Gemfile
- [ ] Confirm Renovate detects and tracks `Gemfile.lint`