### PR TITLE
fix(connection): recover pool entries closed server-side by PgBouncer and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Connection Management
+- **[Fix]** `PGMQ::Connection#verify_connection!` now also resets connections whose status is `PG::CONNECTION_BAD`. Previously it only checked `conn.finished?`, which misses connections closed server-side by the database or an intermediate pooler (PgBouncer `server_idle_timeout` / `client_idle_timeout`, admin kill, TCP RST). A pooled connection with a dead socket would survive `verify_connection!` and fail on the next operation with `PQsocket() can't get socket descriptor`.
+- **[Fix]** `PGMQ::Connection#connection_lost_error?` now recognises `"PQsocket() can't get socket descriptor"` (plus `"connection is closed"` / `"connection has been closed"`). This is the exact error the `pg` gem raises from its C extension when the cached libpq socket FD is gone. Without the match, the `auto_reconnect` retry path in `with_connection` skipped this error and producers failed on the first call following a server-side close.
+
 ## 0.6.0 (2026-04-02)
 
 ### Breaking Changes

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -111,29 +111,41 @@ module PGMQ
     # @param error [PG::Error] the error to check
     # @return [Boolean] true if connection was lost
     def connection_lost_error?(error)
-      # Common connection lost errors
+      # Common connection lost errors. Include the pg-gem C-extension message
+      # ("PQsocket() can't get socket descriptor") that is raised when the
+      # cached libpq socket descriptor is gone — e.g. after a server-side
+      # close by a connection pooler such as PgBouncer.
       lost_connection_messages = [
         "server closed the connection",
         "connection not open",
+        "connection is closed",
+        "connection has been closed",
         "no connection to the server",
         "terminating connection",
         "connection to server was lost",
-        "could not receive data from server"
+        "could not receive data from server",
+        "pqsocket() can't get socket descriptor"
       ]
 
-      message = error.message.downcase
+      message = error.message.to_s.downcase
       lost_connection_messages.any? { |pattern| message.include?(pattern) }
     end
 
-    # Verifies a connection is alive and working
+    # Verifies a connection is alive and working.
+    #
+    # Also resets when the connection reports `PG::CONNECTION_BAD`, which
+    # happens when the server (or an intermediate pooler such as PgBouncer)
+    # has closed the socket while the client-side `PG::Connection` object
+    # still exists. `#finished?` alone only catches connections closed
+    # explicitly from the client side.
+    #
     # @param conn [PG::Connection] connection to verify
-    # @raise [PG::Error] if connection is not working
+    # @raise [PG::Error] if the reset itself fails
     def verify_connection!(conn)
-      # Quick check - is connection object in bad state?
-      return unless conn.finished?
+      return conn.reset if conn.finished?
+      return conn.reset if conn.status == PG::CONNECTION_BAD
 
-      # Connection is finished/closed, try to reset it
-      conn.reset
+      nil
     end
 
     # Normalizes various connection parameter formats

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -293,11 +293,11 @@ describe PGMQ::Connection do
       pg_conn = PG.connect(TEST_DB_PARAMS)
       pg_conn.close
 
-      assert pg_conn.finished?
+      assert_predicate pg_conn, :finished?
 
       connection.send(:verify_connection!, pg_conn)
 
-      refute pg_conn.finished?, "expected verify_connection! to reset a finished connection"
+      refute_predicate pg_conn, :finished?, "expected verify_connection! to reset a finished connection"
       assert_equal "1", pg_conn.exec("SELECT 1").getvalue(0, 0)
     ensure
       pg_conn.close if pg_conn && !pg_conn.finished?

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -249,6 +249,86 @@ describe PGMQ::Connection do
     end
   end
 
+  describe "connection_lost_error? (private)" do
+    let(:connection) { PGMQ::Connection.new(TEST_DB_PARAMS, pool_size: 1) }
+
+    after { connection.close }
+
+    it "matches the pg-gem 'PQsocket' error raised when the cached socket is gone" do
+      # pg gem raises this (see pg_connection.c) when the libpq socket
+      # descriptor has been closed out from under an open PG::Connection,
+      # which happens when a connection pooler such as PgBouncer closes
+      # the server link on idle/lifetime timeout.
+      error = PG::ConnectionBad.new("PQsocket() can't get socket descriptor")
+
+      assert connection.send(:connection_lost_error?, error)
+    end
+
+    it "still matches the pre-existing server-initiated disconnect messages" do
+      %w[
+        server_closed_the_connection_unexpectedly
+        connection_to_server_was_lost
+        no_connection_to_the_server
+      ].each do |key|
+        message = key.tr("_", " ")
+        error = PG::ConnectionBad.new(message)
+
+        assert connection.send(:connection_lost_error?, error), "expected match for #{message.inspect}"
+      end
+    end
+
+    it "does not match unrelated PG errors" do
+      error = PG::Error.new("duplicate key value violates unique constraint")
+
+      refute connection.send(:connection_lost_error?, error)
+    end
+  end
+
+  describe "verify_connection! (private)" do
+    let(:connection) { PGMQ::Connection.new(TEST_DB_PARAMS, pool_size: 1) }
+
+    after { connection.close }
+
+    it "resets connections that are closed client-side (finished? is true)" do
+      pg_conn = PG.connect(TEST_DB_PARAMS)
+      pg_conn.close
+
+      assert pg_conn.finished?
+
+      connection.send(:verify_connection!, pg_conn)
+
+      refute pg_conn.finished?, "expected verify_connection! to reset a finished connection"
+      assert_equal "1", pg_conn.exec("SELECT 1").getvalue(0, 0)
+    ensure
+      pg_conn.close if pg_conn && !pg_conn.finished?
+    end
+
+    it "resets connections whose status is CONNECTION_BAD without finished? flipping true" do
+      pg_conn = PG.connect(TEST_DB_PARAMS)
+
+      # Simulate a server-initiated disconnect (PgBouncer idle timeout, admin
+      # kill, TCP RST) where the cached PG::Connection is still alive enough
+      # that finished? returns false but status reports CONNECTION_BAD.
+      # Return CONNECTION_BAD for the first query only so the subsequent
+      # reset (which re-checks status) can succeed.
+      pg_conn.stubs(:status).returns(PG::CONNECTION_BAD, PG::CONNECTION_OK)
+      pg_conn.expects(:reset).once.returns(pg_conn)
+
+      connection.send(:verify_connection!, pg_conn)
+    ensure
+      pg_conn.close if pg_conn && !pg_conn.finished?
+    end
+
+    it "does not touch healthy connections" do
+      pg_conn = PG.connect(TEST_DB_PARAMS)
+      pg_conn.expects(:reset).never
+
+      connection.send(:verify_connection!, pg_conn)
+    ensure
+      pg_conn&.close
+    end
+  end
+
   describe "connection lifecycle" do
     it "closes all connections properly" do
       client = PGMQ::Client.new(@conn_params, pool_size: 3)


### PR DESCRIPTION
## Summary

Two bugs in `PGMQ::Connection` (`lib/pgmq/connection.rb`) let a stale pooled `PG::Connection` survive the auto-reconnect machinery and surface to the caller as:

```
PGMQ::Errors::ConnectionError: Database connection error: PQsocket() can't get socket descriptor
```

This happens reliably when producers are deployed behind a connection pooler — PgBouncer in particular — where idle server links get closed underneath long-lived client connections (`server_idle_timeout`, `client_idle_timeout`, admin kill, TCP RST). The client-side `PG::Connection` object is still there, but its cached libpq socket descriptor is gone.

## Root cause

### 1. `verify_connection!` only checks `conn.finished?`

`conn.finished?` returns `true` only when the client closed the connection (via `conn.close`/`conn.finish`). A server-initiated close does not flip `finished?` — libpq only notices on the next I/O. So after an idle-timeout reset, the health check passes, `yield conn` runs, and the subsequent `exec` raises.

### 2. `connection_lost_error?` misses the pg-gem error it should match

When the cached socket FD is gone, the `pg` gem raises from its C extension (`pg_connection.c:938`):

```
PQsocket() can't get socket descriptor
```

That string isn't in `connection_lost_error?`'s match list, so `with_connection`'s `retry if connection_lost_error?(e)` skips it and re-raises. For a pooler user this means the first produce after any idle-timeout failure always propagates.

## Fix

- `verify_connection!` also resets when `conn.status == PG::CONNECTION_BAD` — the cheap state bit that catches server-initiated closes.
- `connection_lost_error?` adds `"PQsocket() can't get socket descriptor"`, `"connection is closed"`, and `"connection has been closed"` to the match list so auto_reconnect retries recover them.

Both changes are purely additive to existing behaviour — no callers of the public API change.

## Tests

New coverage under `test/lib/pgmq/connection_test.rb`:

- `connection_lost_error?` matches the pg-gem `PQsocket` string
- Still matches the pre-existing server-disconnect messages
- Does not match unrelated `PG::Error`s
- `verify_connection!` resets client-closed connections (unchanged behaviour, now explicit)
- `verify_connection!` resets connections reporting `CONNECTION_BAD` without `finished?` flipping true
- `verify_connection!` leaves healthy connections alone

All six new tests pass locally against the `docker-compose.yml` postgres. Existing tests unchanged.

## Reproduction

Any deployment where the `PG::Connection` pool spans an idle window longer than PgBouncer's `server_idle_timeout` (default 600s) or `client_idle_timeout` hits this. A low-traffic webhook endpoint is the clearest trigger: idle pool → webhook arrives → `produce` → failure. A retry from the sender masks it, so it often gets logged for a while before someone investigates.

## Notes on scope

I kept the fix narrow on purpose — a full active-liveness ping (`conn.exec("SELECT 1")` at every checkout) would add a round-trip tax to every producer call. The `status == CONNECTION_BAD` check is effectively free and covers the observed failure mode; auto_reconnect's retry handles the remaining corner case where the status bit is still `OK` but the first real query discovers the socket is dead.