### PR TITLE
fix(connection): detect SSL-layer EOF and match PG::ConnectionBad by class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Connection Management
+- **[Fix]** `PGMQ::Connection#connection_lost_error?` now detects SSL-layer teardown errors (`"PQconsumeInput() SSL error: unexpected eof while reading"`, `"SSL SYSCALL error: EOF detected"`). Observed in production behind a managed Postgres pooler: an idle connection torn down at the SSL layer caused the next enqueue to raise `PGMQ::Errors::ConnectionError` without triggering `with_connection`'s single-retry path, because the message didn't match any of the existing substrings.
+- **[Fix]** `PGMQ::Connection#connection_lost_error?` now also matches by class (`PG::ConnectionBad`, `PG::UnableToSend`) in addition to message substrings. These are dedicated connection-failure classes libpq raises when the socket is dead; class-matching catches future OS/pooler/TLS message variants without waiting for them to hit production.
+
 ## 0.6.1 (2026-04-16)
 
 ### Connection Management

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -107,28 +107,42 @@ module PGMQ
 
     private
 
-    # Checks if the error indicates a lost connection
+    # Messages libpq raises when the server/pooler has already torn down the
+    # socket. The list has grown organically with each pooler/TLS variant we
+    # see in the wild; the class check below catches future variants that
+    # libpq raises as `PG::ConnectionBad` or `PG::UnableToSend` without
+    # waiting for a new message to hit production.
+    LOST_CONNECTION_MESSAGES = [
+      "server closed the connection",
+      "connection not open",
+      "connection is closed",
+      "connection has been closed",
+      "no connection to the server",
+      "terminating connection",
+      "connection to server was lost",
+      "could not receive data from server",
+      "pqsocket() can't get socket descriptor",
+      "ssl error: unexpected eof",
+      "ssl syscall error"
+    ].freeze
+    private_constant :LOST_CONNECTION_MESSAGES
+
+    # Checks if the error indicates a lost connection.
+    #
+    # Matches in two steps: first by class (`PG::ConnectionBad` /
+    # `PG::UnableToSend` are dedicated connection-failure classes libpq
+    # raises regardless of message), then by message substring for the
+    # bare `PG::Error` cases where libpq doesn't reach for the specific
+    # subclass.
+    #
     # @param error [PG::Error] the error to check
-    # @return [Boolean] true if connection was lost
+    # @return [Boolean] true if the connection was lost and a retry on a
+    #   fresh connection is appropriate
     def connection_lost_error?(error)
-      # Common connection lost errors. Include the pg-gem C-extension message
-      # ("PQsocket() can't get socket descriptor") that is raised when the
-      # cached libpq socket descriptor is gone — e.g. after a server-side
-      # close by a connection pooler such as PgBouncer.
-      lost_connection_messages = [
-        "server closed the connection",
-        "connection not open",
-        "connection is closed",
-        "connection has been closed",
-        "no connection to the server",
-        "terminating connection",
-        "connection to server was lost",
-        "could not receive data from server",
-        "pqsocket() can't get socket descriptor"
-      ]
+      return true if error.is_a?(PG::ConnectionBad) || error.is_a?(PG::UnableToSend)
 
       message = error.message.to_s.downcase
-      lost_connection_messages.any? { |pattern| message.include?(pattern) }
+      LOST_CONNECTION_MESSAGES.any? { |pattern| message.include?(pattern) }
     end
 
     # Verifies a connection is alive and working.

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -282,6 +282,44 @@ describe PGMQ::Connection do
 
       refute connection.send(:connection_lost_error?, error)
     end
+
+    it "matches SSL-layer EOF raised when libpq's read returns 0 on a dead socket" do
+      # Observed in production behind a managed Postgres pooler: an idle
+      # connection is torn down at the SSL layer and the next I/O raises
+      # this exact message. Semantically identical to "could not receive
+      # data from server" (which is already covered), just one layer down.
+      error = PG::ConnectionBad.new(
+        "PQconsumeInput() SSL error: unexpected eof while reading"
+      )
+
+      assert connection.send(:connection_lost_error?, error)
+    end
+
+    it "matches SSL SYSCALL teardown errors" do
+      error = PG::ConnectionBad.new(
+        "SSL SYSCALL error: EOF detected"
+      )
+
+      assert connection.send(:connection_lost_error?, error)
+    end
+
+    it "matches PG::ConnectionBad by class, even when the message is opaque" do
+      # libpq doesn't promise a stable message for every pooler/OS/TLS
+      # combination, but it does raise a dedicated class for connection
+      # failures. Class-matching catches future message variants without
+      # growing the string list.
+      error = PG::ConnectionBad.new("")
+
+      assert connection.send(:connection_lost_error?, error)
+    end
+
+    it "matches PG::UnableToSend by class" do
+      # Raised by libpq when the write side of the connection is gone —
+      # another dedicated connection-failure class.
+      error = PG::UnableToSend.new("")
+
+      assert connection.send(:connection_lost_error?, error)
+    end
   end
 
   describe "verify_connection! (private)" do


### PR DESCRIPTION
## Summary

Closes gaps in `PGMQ::Connection#connection_lost_error?` that let
transient Postgres drops propagate as `PGMQ::Errors::ConnectionError`
even though the connection would recover on the next checkout.

Two complementary changes:

1. **Match by class first.** `PG::ConnectionBad` and `PG::UnableToSend`
   are libpq's dedicated connection-failure classes. Matching them
   directly catches future OS/pooler/TLS variants without waiting for a
   new message to hit production.
2. **Extend the substring list.** Added `"ssl error: unexpected eof"`
   and `"ssl syscall error"` for the bare `PG::Error` cases where libpq
   doesn't reach for the subclass.

The substring list is also extracted into a private constant
(`LOST_CONNECTION_MESSAGES`) so it's easier to find and grow.

Tracked in #98.

## Motivation

Observed in production behind a managed Postgres pooler. An idle SSL
teardown caused three unrelated controllers to hit the same enqueue
error in a six-minute window, then recover without intervention:

```
Database connection error: PQconsumeInput() SSL error: unexpected eof while reading
```

Stack (top frames pgmq-ruby):

```
pgmq-ruby (0.6.1) lib/pgmq/connection.rb:81:in 'PGMQ::Connection#with_connection'
pgmq-ruby (0.6.1) lib/pgmq/client.rb:102:in 'PGMQ::Client#with_connection'
pgmq-ruby (0.6.1) lib/pgmq/client/queue_management.rb:23:in 'PGMQ::Client::QueueManagement#create'
```

An earlier cluster in the same app raised the same exception class with
a different message — `PQsocket() can't get socket descriptor` — which
IS matched by `connection_lost_error?` and was retried successfully.
The machinery works; only the pattern coverage was the gap.

### Why `verify_connection!` doesn't catch it

`verify_connection!` runs before `yield conn` and checks
`conn.finished?` / `conn.status == PG::CONNECTION_BAD`. For an idle
connection silently killed at the SSL layer, `PQstatus()` often still
reports `CONNECTION_OK` until the next I/O, because libpq only flips
the status after a failed operation. The first I/O inside the yielded
block is what raises `PQconsumeInput() SSL error: unexpected eof`, and
at that point execution is already in the `rescue PG::Error` branch —
so recovery depends on `connection_lost_error?`.

## Changes

- `lib/pgmq/connection.rb`
  - Extract substrings into private constant `LOST_CONNECTION_MESSAGES`.
  - Add `"ssl error: unexpected eof"` and `"ssl syscall error"` to the
    list.
  - `connection_lost_error?` now returns `true` up-front for
    `PG::ConnectionBad` / `PG::UnableToSend` before falling back to
    substring matching.
- `test/lib/pgmq/connection_test.rb` — four new tests:
  - SSL EOF message.
  - SSL SYSCALL message.
  - `PG::ConnectionBad` with an empty/opaque message.
  - `PG::UnableToSend` with an empty/opaque message.
- `CHANGELOG.md` — Unreleased section documenting both fixes.

## Risk / backwards compatibility

Strictly widens the set of errors that trigger a single retry; does not
narrow it. Existing message matches are unchanged. The class check is
conditional on the error being `PG::ConnectionBad` / `PG::UnableToSend`
— neither is raised for query-level problems (syntax errors, constraint
violations, etc.), so no query error is silently retried.

## Test plan

- [x] `bundle exec rake test` — `267 runs, 0 failures, 2 skips` (both
      skips pre-existing and unrelated)
- [x] `bundle exec rake test TESTOPTS=--name=/connection_lost_error/` —
      `7 runs, 0 failures` (3 pre-existing + 4 new)
- [x] RED-GREEN confirmed: with implementation reverted the 4 new tests
      fail; with implementation applied they pass.
- [x] StandardRB clean on new code (pre-existing offenses on unrelated
      lines, unchanged).

## Cross-reference

Parallel issue in pgbus (consumer of pgmq-ruby) where a matching gap
exists on its enqueue path: mhenrixon/pgbus#143. Fixing only one of
the two gems leaves a narrower but still real window.