### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.2 (2026-05-08)
+
 ### Connection Management
 - **[Feature]** Add class-level configuration for extending reconnectable error detection. `PGMQ::Connection.reconnectable_error_patterns` accepts additional `String` or `Regexp` patterns (strings matched as case-insensitive substrings; regexps against the original message). `PGMQ::Connection.reconnectable_error_classes` accepts additional `Exception` subclasses. This allows users to adapt to new pg gem / PostgreSQL / pooler disconnect signatures without waiting for a gem release.
 - **[Fix]** `PGMQ::Connection#connection_lost_error?` now detects SSL-layer teardown errors (`"PQconsumeInput() SSL error: unexpected eof while reading"`, `"SSL SYSCALL error: EOF detected"`). Observed in production behind a managed Postgres pooler: an idle connection torn down at the SSL layer caused the next enqueue to raise `PGMQ::Errors::ConnectionError` without triggering `with_connection`'s single-retry path, because the message didn't match any of the existing substrings.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pgmq-ruby (0.6.1)
+    pgmq-ruby (0.6.2)
       connection_pool (~> 2.4)
       pg (~> 1.5)
       zeitwerk (~> 2.6)

--- a/lib/pgmq/version.rb
+++ b/lib/pgmq/version.rb
@@ -2,5 +2,5 @@
 
 module PGMQ
   # Current version of the pgmq-ruby gem
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
## Summary
- Bump version to 0.6.2
- Update CHANGELOG.md with release date (2026-05-08)
- Update Gemfile.lock

### Changes included in this release

**Connection Management**
- **[Feature]** Extensible reconnectable-error matchers via `PGMQ::Connection.reconnectable_error_patterns` and `PGMQ::Connection.reconnectable_error_classes`
- **[Fix]** Detect SSL-layer teardown errors (`PQconsumeInput() SSL error`, `SSL SYSCALL error: EOF detected`)
- **[Fix]** Match connection errors by class (`PG::ConnectionBad`, `PG::UnableToSend`) in addition to message substrings

## Test plan
- [ ] CI passes on all Ruby versions
- [ ] Gem builds successfully