### PR TITLE
Enhancement: Add Ruby warning category opt-in to test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- **[Enhancement]** Add Ruby warning category opt-in to test helpers
 
 ## 0.6.2 (2026-05-08)
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ end
 
 group :test do
   gem "simplecov", require: false
+  gem "warning"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     traces (0.18.2)
+    warning (1.6.0)
     zeitwerk (2.8.2)
 
 PLATFORMS
@@ -69,6 +70,7 @@ DEPENDENCIES
   pgmq-ruby!
   rake
   simplecov
+  warning
 
 BUNDLED WITH
    2.7.2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,6 @@ if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
-else
-  Warning[:deprecated] = true
-  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
 
 Warning.process do |warning|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= '3.3'
-Warning[:deprecated] = true
+require 'warning'
+
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
+else
+  Warning[:deprecated] = true
+  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
-
-require 'warning'
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,9 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each do |cat|
+    Warning[cat] = true
+  end
 end
 
 require 'warning'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
 end
 
 require 'warning'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+Warning[:performance] = true if RUBY_VERSION >= '3.3'
+Warning[:deprecated] = true
+$VERBOSE = true
+
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
+require 'warning'
+
+Warning.process do |warning|
+  next unless warning.include?(Dir.pwd)
+  next if warning.include?('_test')
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+  next if warning.include?('vendor/')
+  next if warning.include?('bundle/')
+  next if warning.include?('.bundle/')
+  raise "Warning in your code: #{warning}"
+end
+
 # SimpleCov must be loaded before application code
 require "simplecov"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'warning'
+require "warning"
 
 $VERBOSE = true
 
@@ -12,10 +12,11 @@ end
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
-  next if warning.include?('_test')
-  next if warning.include?('vendor/')
-  next if warning.include?('bundle/')
-  next if warning.include?('.bundle/')
+  next if warning.include?("_test")
+  next if warning.include?("vendor/")
+  next if warning.include?("bundle/")
+  next if warning.include?(".bundle/")
+
   raise "Warning in your code: #{warning}"
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,6 @@ end
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
   next if warning.include?('_test')
-  next if warning.include?('previous definition of')
-  next if warning.include?('method redefined')
   next if warning.include?('vendor/')
   next if warning.include?('bundle/')
   next if warning.include?('.bundle/')


### PR DESCRIPTION
## Summary

- Adds `gem 'warning'` to the test group in Gemfile
- Configures Ruby warning categories (`deprecated`, `performance` on Ruby ≥ 3.3) at the top of `test/test_helper.rb`
- Uses `Warning.process` to raise on any warnings originating from project code, helping catch issues early
- Updates CHANGELOG.md with the enhancement entry

## Test plan

- [ ] `bundle install` succeeds (Gemfile.lock updated with `warning` gem)
- [ ] Existing test suite continues to pass
- [ ] Any Ruby warnings in project code will raise as errors during test runs