### PR TITLE
Feature: add read_grouped and read_grouped_with_poll (SQS-style grouped reads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers
+- **[Feature]** Add SQS-style grouped reading:
+  - `read_grouped(queue_name, vt:, qty:)` — reads messages grouped by the first JSON key,
+    filling the batch from the oldest group first (throughput-optimised). Contrast with
+    `read_grouped_rr` which interleaves groups fairly.
+  - `read_grouped_with_poll(queue_name, vt:, qty:, max_poll_seconds:, poll_interval_ms:)` —
+    same strategy with long-polling support.
+
+  Use `read_grouped` when maximising throughput matters more than fairness across groups
+  (e.g. a single tenant has a burst of work). Use `read_grouped_rr` when you need to
+  prevent any one group from monopolising workers.
 - **[Feature]** `produce`, `produce_batch`, and `produce_batch_topic` now accept an absolute `Time`
   object for the `delay:` parameter in addition to an integer number of seconds. This mirrors the
   existing `set_vt` behaviour and maps to the `timestamptz` overloads added in PGMQ v1.10.0.

--- a/lib/pgmq/client/consumer.rb
+++ b/lib/pgmq/client/consumer.rb
@@ -151,6 +151,82 @@ module PGMQ
         result.map { |row| Message.new(row) }
       end
 
+      # Reads messages using SQS-style grouped ordering (throughput-optimised)
+      #
+      # Messages are grouped by the first key in their JSON payload. Unlike
+      # round-robin, this strategy fills the requested batch from the oldest
+      # group first, then moves on to the next group only when the first is
+      # exhausted. Maximises throughput for bursty workloads at the cost of
+      # fairness across groups.
+      #
+      # @param queue_name [String] name of the queue
+      # @param vt [Integer] visibility timeout in seconds
+      # @param qty [Integer] number of messages to read
+      # @return [Array<PGMQ::Message>] array of messages, oldest group first
+      #
+      # @example Throughput-first batch processing
+      #   # Queue contains: user1_msg1, user1_msg2, user2_msg1
+      #   messages = client.read_grouped("tasks", vt: 30, qty: 3)
+      #   # Returns: user1_msg1, user1_msg2, user2_msg1  (drains user1 first)
+      #
+      # @example High-volume processing where fairness is not required
+      #   loop do
+      #     messages = client.read_grouped("jobs", vt: 30, qty: 20)
+      #     break if messages.empty?
+      #     messages.each { |msg| process(msg) }
+      #   end
+      def read_grouped(queue_name, vt: DEFAULT_VT, qty: 1)
+        validate_queue_name!(queue_name)
+
+        result = with_connection do |conn|
+          conn.exec_params(
+            "SELECT * FROM pgmq.read_grouped($1::text, $2::integer, $3::integer)",
+            [queue_name, vt, qty]
+          )
+        end
+
+        result.map { |row| Message.new(row) }
+      end
+
+      # Reads messages using SQS-style grouped ordering with long-polling support
+      #
+      # Combines SQS-style throughput-first grouped ordering with long-polling.
+      # Blocks up to max_poll_seconds if the queue is empty, returning as soon
+      # as any message arrives.
+      #
+      # @param queue_name [String] name of the queue
+      # @param vt [Integer] visibility timeout in seconds
+      # @param qty [Integer] number of messages to read
+      # @param max_poll_seconds [Integer] maximum time to poll in seconds
+      # @param poll_interval_ms [Integer] interval between polls in milliseconds
+      # @return [Array<PGMQ::Message>] array of messages
+      #
+      # @example Poll with throughput-first grouped ordering
+      #   messages = client.read_grouped_with_poll("jobs",
+      #     vt: 30,
+      #     qty: 10,
+      #     max_poll_seconds: 5,
+      #     poll_interval_ms: 100
+      #   )
+      def read_grouped_with_poll(
+        queue_name,
+        vt: DEFAULT_VT,
+        qty: 1,
+        max_poll_seconds: 5,
+        poll_interval_ms: 100
+      )
+        validate_queue_name!(queue_name)
+
+        result = with_connection do |conn|
+          conn.exec_params(
+            "SELECT * FROM pgmq.read_grouped_with_poll($1::text, $2::integer, $3::integer, $4::integer, $5::integer)",
+            [queue_name, vt, qty, max_poll_seconds, poll_interval_ms]
+          )
+        end
+
+        result.map { |row| Message.new(row) }
+      end
+
       # Reads messages using grouped round-robin ordering
       #
       # Messages are grouped by the first key in their JSON payload and returned

--- a/test/lib/pgmq/client/consumer_test.rb
+++ b/test/lib/pgmq/client/consumer_test.rb
@@ -234,7 +234,287 @@ describe PGMQ::Client::Consumer do
     end
   end
 
-  describe "#read_grouped_rr" do
+  describe "#read_grouped" do
+    it "returns an empty array for an empty queue" do
+      assert_equal [], @client.read_grouped(@queue_name, vt: 30, qty: 5)
+    end
+
+    it "returns PGMQ::Message objects" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1", seq: 1 }))
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 1)
+
+      assert_equal 1, messages.size
+      assert_kind_of PGMQ::Message, messages.first
+    end
+
+    it "returns all expected message fields" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1", val: 42 }))
+
+      msg = @client.read_grouped(@queue_name, vt: 30, qty: 1).first
+
+      assert_respond_to msg, :msg_id
+      assert_respond_to msg, :message
+      assert_respond_to msg, :read_ct
+      assert_respond_to msg, :enqueued_at
+      assert_respond_to msg, :vt
+      assert_equal({ "user_id" => "u1", "val" => 42 }, JSON.parse(msg.message))
+    end
+
+    it "respects the qty limit" do
+      5.times { |i| @client.produce(@queue_name, to_json_msg({ user_id: "u1", seq: i })) }
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 3)
+
+      assert_equal 3, messages.size
+    end
+
+    it "reads fewer messages than qty when queue has less" do
+      2.times { |i| @client.produce(@queue_name, to_json_msg({ user_id: "u1", seq: i })) }
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 10)
+
+      assert_equal 2, messages.size
+    end
+
+    it "respects visibility timeout — message hidden during vt" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      first = @client.read_grouped(@queue_name, vt: 2, qty: 1)
+
+      assert_equal 1, first.size
+
+      second = @client.read_grouped(@queue_name, vt: 2, qty: 1)
+
+      assert_empty second
+
+      sleep 2.5
+
+      third = @client.read_grouped(@queue_name, vt: 30, qty: 1)
+
+      assert_equal 1, third.size
+      assert_equal first.first.msg_id, third.first.msg_id
+    end
+
+    it "drains the oldest group first (SQS-style throughput ordering)" do
+      # user1 has 3 messages, user2 has 1 — requesting qty: 3 should drain user1 first
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 2 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 3 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user2", seq: 1 }))
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 3)
+
+      assert_equal 3, messages.size
+      user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
+      # All 3 should be from user1 — oldest group drained first
+      assert_equal ["user1"] * 3, user_ids
+    end
+
+    it "reads from next group once the first is exhausted" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user2", seq: 1 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user2", seq: 2 }))
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 3)
+
+      assert_equal 3, messages.size
+      user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
+      assert_includes user_ids, "user1"
+      assert_includes user_ids, "user2"
+    end
+
+    it "handles a single-group queue" do
+      3.times { |i| @client.produce(@queue_name, to_json_msg({ tenant: "acme", seq: i })) }
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 3)
+
+      assert_equal 3, messages.size
+      messages.each { |m| assert_equal "acme", JSON.parse(m.message)["tenant"] }
+    end
+
+    it "handles many groups with qty smaller than total messages" do
+      %w[a b c d e].each do |user|
+        2.times { |i| @client.produce(@queue_name, to_json_msg({ user_id: user, seq: i })) }
+      end
+
+      messages = @client.read_grouped(@queue_name, vt: 30, qty: 4)
+
+      assert_equal 4, messages.size
+      messages.each { |m| assert_kind_of PGMQ::Message, m }
+    end
+
+    it "validates the queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.read_grouped("invalid queue!", vt: 30, qty: 1)
+      end
+    end
+
+    it "increments read_ct on subsequent reads after vt expires" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      first = @client.read_grouped(@queue_name, vt: 2, qty: 1).first
+
+      assert_equal "1", first.read_ct
+
+      sleep 2.5
+
+      second = @client.read_grouped(@queue_name, vt: 30, qty: 1).first
+
+      assert_equal "2", second.read_ct
+    end
+
+    it "uses DEFAULT_VT when vt not specified" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      messages = @client.read_grouped(@queue_name, qty: 1)
+
+      assert_equal 1, messages.size
+    end
+  end
+
+  describe "#read_grouped_with_poll" do
+    it "returns an empty array when queue stays empty within timeout" do
+      start_time = Time.now
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 1,
+        max_poll_seconds: 1,
+        poll_interval_ms: 100
+      )
+      elapsed = Time.now - start_time
+
+      assert_empty messages
+      assert_operator elapsed, :>=, 1
+    end
+
+    it "returns immediately when messages already exist" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      start_time = Time.now
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 1,
+        max_poll_seconds: 5,
+        poll_interval_ms: 100
+      )
+      elapsed = Time.now - start_time
+
+      assert_equal 1, messages.size
+      assert_operator elapsed, :<, 1.0
+    end
+
+    it "waits for a message that arrives during polling" do
+      Thread.new do
+        sleep 0.5
+        @client.produce(@queue_name, to_json_msg({ user_id: "u1", arrived: true }))
+      end
+
+      start_time = Time.now
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 1,
+        max_poll_seconds: 3,
+        poll_interval_ms: 100
+      )
+      elapsed = Time.now - start_time
+
+      refute_empty messages
+      assert_operator elapsed, :>=, 0.5
+      assert_operator elapsed, :<, 3.0
+      assert_equal true, JSON.parse(messages.first.message)["arrived"]
+    end
+
+    it "returns PGMQ::Message objects" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 1,
+        max_poll_seconds: 2,
+        poll_interval_ms: 100
+      )
+
+      assert_kind_of PGMQ::Message, messages.first
+    end
+
+    it "respects the qty limit" do
+      5.times { |i| @client.produce(@queue_name, to_json_msg({ user_id: "u1", seq: i })) }
+
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 3,
+        max_poll_seconds: 2,
+        poll_interval_ms: 50
+      )
+
+      assert_equal 3, messages.size
+    end
+
+    it "drains the oldest group first (same SQS-style semantics as read_grouped)" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 2 }))
+      @client.produce(@queue_name, to_json_msg({ user_id: "user2", seq: 1 }))
+
+      messages = @client.read_grouped_with_poll(
+        @queue_name,
+        vt: 30,
+        qty: 2,
+        max_poll_seconds: 2,
+        poll_interval_ms: 50
+      )
+
+      assert_equal 2, messages.size
+      user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
+      assert_equal ["user1", "user1"], user_ids
+    end
+
+    it "uses default poll parameters" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      messages = @client.read_grouped_with_poll(@queue_name)
+
+      assert_equal 1, messages.size
+    end
+
+    it "validates the queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.read_grouped_with_poll("bad name!", vt: 30, qty: 1)
+      end
+    end
+
+    it "respects visibility timeout on polled messages" do
+      @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
+
+      first = @client.read_grouped_with_poll(
+        @queue_name, vt: 2, qty: 1, max_poll_seconds: 2, poll_interval_ms: 50
+      )
+
+      assert_equal 1, first.size
+
+      second = @client.read_grouped_with_poll(
+        @queue_name, vt: 2, qty: 1, max_poll_seconds: 1, poll_interval_ms: 50
+      )
+
+      assert_empty second
+
+      sleep 2.5
+
+      third = @client.read_grouped_with_poll(
+        @queue_name, vt: 30, qty: 1, max_poll_seconds: 2, poll_interval_ms: 50
+      )
+
+      assert_equal 1, third.size
+      assert_equal first.first.msg_id, third.first.msg_id
+    end
+  end
+
+describe "#read_grouped_rr" do
     it "reads messages in round-robin order across groups" do
       # Send messages from different "users" (grouped by first key value)
       @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))

--- a/test/lib/pgmq/client/consumer_test.rb
+++ b/test/lib/pgmq/client/consumer_test.rb
@@ -320,6 +320,7 @@ describe PGMQ::Client::Consumer do
 
       assert_equal 3, messages.size
       user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
+
       assert_includes user_ids, "user1"
       assert_includes user_ids, "user2"
     end
@@ -425,7 +426,7 @@ describe PGMQ::Client::Consumer do
       refute_empty messages
       assert_operator elapsed, :>=, 0.5
       assert_operator elapsed, :<, 3.0
-      assert_equal true, JSON.parse(messages.first.message)["arrived"]
+      assert JSON.parse(messages.first.message)["arrived"]
     end
 
     it "returns PGMQ::Message objects" do
@@ -471,6 +472,7 @@ describe PGMQ::Client::Consumer do
 
       assert_equal 2, messages.size
       user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
+
       assert_equal ["user1", "user1"], user_ids
     end
 
@@ -514,7 +516,7 @@ describe PGMQ::Client::Consumer do
     end
   end
 
-describe "#read_grouped_rr" do
+  describe "#read_grouped_rr" do
     it "reads messages in round-robin order across groups" do
       # Send messages from different "users" (grouped by first key value)
       @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))


### PR DESCRIPTION
## Summary

- Add `read_grouped(queue_name, vt:, qty:)` — wraps `pgmq.read_grouped`, fills the batch from the **oldest group first** (throughput-optimised, SQS-style)
- Add `read_grouped_with_poll(queue_name, vt:, qty:, max_poll_seconds:, poll_interval_ms:)` — same strategy with long-polling
- Both complement the existing `read_grouped_rr` / `read_grouped_rr_with_poll` methods; the two strategies have distinct semantics:
  - `read_grouped` — drains the oldest group first, maximises throughput in bursty workloads
  - `read_grouped_rr` — interleaves one message from each group, prevents starvation

## Usage

```ruby
# Throughput-first: drain user1's backlog before moving to user2
messages = client.read_grouped("jobs", vt: 30, qty: 10)

# With long-polling — blocks up to 5s if queue is empty
messages = client.read_grouped_with_poll("jobs",
  vt: 30,
  qty: 10,
  max_poll_seconds: 5,
  poll_interval_ms: 100
)
```

## Test plan

22 new tests across both methods covering:

- [x] Empty queue returns `[]`
- [x] Returns `PGMQ::Message` objects
- [x] All expected message fields present
- [x] `qty` limit respected
- [x] Fewer messages than `qty` — returns what's available
- [x] Visibility timeout — message hidden during VT, visible after expiry
- [x] Oldest-group-first ordering (3 user1 msgs + 1 user2 msg → all 3 slots go to user1)
- [x] Reads from next group once first is exhausted
- [x] Single-group queue
- [x] Many groups with qty smaller than total
- [x] Queue name validation raises `InvalidQueueNameError`
- [x] `read_ct` incremented on subsequent reads
- [x] Default `vt:` parameter works
- [x] Long-poll: returns empty after timeout
- [x] Long-poll: returns immediately when messages already exist
- [x] Long-poll: waits for message that arrives during polling
- [x] Long-poll: `qty` limit respected
- [x] Long-poll: SQS-style ordering preserved
- [x] Long-poll: default parameters work
- [x] Long-poll: queue name validation
- [x] Long-poll: VT respected on polled messages
- [x] 309 total tests pass (0 failures, 0 errors)