### PR TITLE
Feature: add read_grouped_head for FIFO group head sampling (PGMQ v1.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers
+- **[Feature]** Add `read_grouped_head(queue_name, vt:, qty:)` — reads exactly one message (the
+  oldest visible) from each distinct FIFO group, up to `qty` groups. Groups are identified by the
+  `x-pgmq-group` key in message headers (set via `headers:` on `produce`); messages without that
+  header all share one implicit default group. Unlike `read_grouped` (which groups by the first
+  payload key and drains one group fully before moving on), `read_grouped_head` surfaces the
+  leading edge of every group in a single call — ideal for detecting head-of-line stalls or
+  building per-group progress dashboards. Requires PGMQ v1.11.1+.
 - **[Feature]** Add SQS-style grouped reading:
   - `read_grouped(queue_name, vt:, qty:)` — reads messages grouped by the first JSON key,
     filling the batch from the oldest group first (throughput-optimised). Contrast with

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PGMQ-Ruby is a Ruby client for PGMQ (PostgreSQL Message Queue). It provides dire
   - [Queue Management](#queue-management)
   - [Sending Messages](#sending-messages)
   - [Reading Messages](#reading-messages)
-  - [Grouped Round-Robin Reading](#grouped-round-robin-reading)
+  - [Grouped Reading](#grouped-reading)
   - [Message Lifecycle](#message-lifecycle)
   - [Monitoring](#monitoring)
   - [Transaction Support](#transaction-support)
@@ -49,8 +49,11 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | **Reading** | `read` | Read single message with visibility timeout | ✅ |
 | | `read_batch` | Read multiple messages with visibility timeout | ✅ |
 | | `read_with_poll` | Long-polling for efficient message consumption | ✅ |
+| | `read_grouped` | SQS-style throughput-first grouped reading | ✅ |
+| | `read_grouped_with_poll` | Throughput-first grouped reading with long-polling | ✅ |
 | | `read_grouped_rr` | Round-robin reading across message groups | ✅ |
 | | `read_grouped_rr_with_poll` | Round-robin with long-polling | ✅ |
+| | `read_grouped_head` | One message per FIFO group from the head of each group | ✅ |
 | | `pop` | Atomic read + delete operation | ✅ |
 | | `pop_batch` | Atomic batch read + delete operation | ✅ |
 | **Deleting/Archiving** | `delete` | Delete single message | ✅ |
@@ -443,6 +446,18 @@ msg = client.pop("queue_name")
 # Pop batch (atomic read + delete for multiple messages)
 messages = client.pop_batch("queue_name", 10)
 
+# SQS-style grouped reading (throughput-first: drains oldest group before moving on)
+# Messages grouped by first key in their JSON payload
+messages = client.read_grouped("queue_name", vt: 30, qty: 10)
+
+# Throughput-first grouped reading with long-polling
+messages = client.read_grouped_with_poll("queue_name",
+  vt: 30,
+  qty: 10,
+  max_poll_seconds: 5,
+  poll_interval_ms: 100
+)
+
 # Grouped round-robin reading (fair processing across entities)
 # Messages are grouped by the first key in their JSON payload
 messages = client.read_grouped_rr("queue_name", vt: 30, qty: 10)
@@ -454,38 +469,82 @@ messages = client.read_grouped_rr_with_poll("queue_name",
   max_poll_seconds: 5,
   poll_interval_ms: 100
 )
+
+# Read one message per FIFO group from the head of each group
+# Groups are set via x-pgmq-group header (requires PGMQ v1.11.1+)
+client.produce("queue_name", '{"job":"a"}', headers: '{"x-pgmq-group":"tenant_a"}')
+client.produce("queue_name", '{"job":"b"}', headers: '{"x-pgmq-group":"tenant_b"}')
+messages = client.read_grouped_head("queue_name", vt: 30, qty: 10)
+# => one message from tenant_a and one from tenant_b
 ```
 
-#### Grouped Round-Robin Reading
+#### Grouped Reading
 
-When processing messages from multiple entities (users, orders, tenants), regular FIFO ordering can cause starvation - one entity with many messages can monopolize workers.
+PGMQ provides three grouped-reading strategies for processing messages from multiple entities (users, tenants, orders). All three group by the **first key** in the JSON payload (except `read_grouped_head`, which uses the `x-pgmq-group` message header).
 
-Grouped round-robin ensures fair processing by interleaving messages from different groups:
+##### Throughput-First (`read_grouped` / `read_grouped_with_poll`)
+
+Drains the oldest group completely before moving to the next. Best when maximising throughput matters more than fairness:
 
 ```ruby
-# Queue contains messages for different users:
-# user_a: 5 messages, user_b: 2 messages, user_c: 1 message
+# Queue: user_a has 3 messages, user_b has 1
+messages = client.read_grouped("tasks", vt: 30, qty: 3)
+# => [user_a_1, user_a_2, user_a_3]  — drains user_a first
 
-# Regular read would process all user_a messages first (unfair)
-messages = client.read_batch("tasks", vt: 30, qty: 8)
-# => [user_a_1, user_a_2, user_a_3, user_a_4, user_a_5, user_b_1, user_b_2, user_c_1]
+# With long-polling (waits up to max_poll_seconds if queue is empty)
+messages = client.read_grouped_with_poll("tasks",
+  vt: 30,
+  qty: 10,
+  max_poll_seconds: 5,
+  poll_interval_ms: 100
+)
+```
 
-# Grouped round-robin ensures fair distribution
+##### Round-Robin (`read_grouped_rr` / `read_grouped_rr_with_poll`)
+
+Interleaves one message per group on each pass. Best for fairness — prevents any single entity from monopolising workers:
+
+```ruby
+# Queue: user_a: 5 messages, user_b: 2, user_c: 1
 messages = client.read_grouped_rr("tasks", vt: 30, qty: 8)
 # => [user_a_1, user_b_1, user_c_1, user_a_2, user_b_2, user_a_3, user_a_4, user_a_5]
+
+# With long-polling
+messages = client.read_grouped_rr_with_poll("tasks",
+  vt: 30,
+  qty: 10,
+  max_poll_seconds: 5,
+  poll_interval_ms: 100
+)
 ```
 
-**How it works:**
-- Messages are grouped by the **first key** in their JSON payload
-- The first key should be your grouping identifier (e.g., `user_id`, `tenant_id`, `order_id`)
-- PGMQ rotates through groups, taking one message from each before repeating
-
-**Message format for grouping:**
+**Message format for payload-based grouping** (used by `read_grouped` and `read_grouped_rr`):
 ```ruby
-# Good - user_id is first key, used for grouping
+# user_id is first key — PGMQ uses it as the group identifier
 client.produce("tasks", '{"user_id":"user_a","task":"process"}')
+```
 
-# The grouping key should come first in your JSON
+##### Head-of-Group (`read_grouped_head`) — PGMQ v1.11.1+
+
+Returns the oldest visible message from each FIFO group, up to `qty` groups. Groups are identified by the `x-pgmq-group` key in the message **headers**. Messages without that header all share one implicit default group.
+
+Useful for detecting head-of-line stalls or building per-group progress dashboards — one call surfaces the leading edge of every group simultaneously:
+
+```ruby
+# Produce with x-pgmq-group headers
+client.produce("jobs", '{"task":"build"}', headers: '{"x-pgmq-group":"tenant_a"}')
+client.produce("jobs", '{"task":"build"}', headers: '{"x-pgmq-group":"tenant_a"}')
+client.produce("jobs", '{"task":"test"}',  headers: '{"x-pgmq-group":"tenant_b"}')
+
+# Returns one message per group (oldest from each)
+messages = client.read_grouped_head("jobs", vt: 30, qty: 100)
+# => [tenant_a oldest msg, tenant_b oldest msg]
+
+# Check for stuck groups
+messages.each do |msg|
+  group = JSON.parse(msg.headers)["x-pgmq-group"]
+  puts "#{group} head enqueued at #{msg.enqueued_at}"
+end
 ```
 
 #### Conditional Message Filtering

--- a/lib/pgmq/client/consumer.rb
+++ b/lib/pgmq/client/consumer.rb
@@ -227,6 +227,51 @@ module PGMQ
         result.map { |row| Message.new(row) }
       end
 
+      # Reads one message per FIFO group from the head of each group
+      #
+      # Returns exactly one message — the oldest visible message — from each
+      # distinct FIFO group, up to qty groups. Groups are determined by the
+      # `x-pgmq-group` key in the message headers (set via the `headers:` param
+      # on `produce`). Messages without that header key all land in a single
+      # implicit default group, so only one of them is returned per call.
+      #
+      # Unlike `read_grouped` (which groups by the first payload key and drains
+      # one group fully before moving to the next), `read_grouped_head` surfaces
+      # the leading edge of every group in one call — useful for detecting
+      # head-of-line stalls or building per-group progress dashboards.
+      #
+      # @note Requires PGMQ v1.11.1+.
+      #
+      # @param queue_name [String] name of the queue
+      # @param vt [Integer] visibility timeout in seconds
+      # @param qty [Integer] maximum number of groups to sample
+      # @return [Array<PGMQ::Message>] one message per group, up to qty
+      #
+      # @example Sample the head of each group
+      #   # Produce with x-pgmq-group headers so each tenant is a separate group
+      #   client.produce("tasks", '{"job":"build"}', headers: '{"x-pgmq-group":"tenant_a"}')
+      #   client.produce("tasks", '{"job":"test"}',  headers: '{"x-pgmq-group":"tenant_b"}')
+      #   messages = client.read_grouped_head("tasks", vt: 30, qty: 10)
+      #   # Returns: one message from tenant_a and one from tenant_b
+      #
+      # @example Monitor for stuck groups
+      #   heads = client.read_grouped_head("jobs", vt: 30, qty: 100)
+      #   heads.each do |msg|
+      #     alert_if_stuck(msg) if msg.enqueued_at < Time.now - 3600
+      #   end
+      def read_grouped_head(queue_name, vt: DEFAULT_VT, qty: 1)
+        validate_queue_name!(queue_name)
+
+        result = with_connection do |conn|
+          conn.exec_params(
+            "SELECT * FROM pgmq.read_grouped_head($1::text, $2::integer, $3::integer)",
+            [queue_name, vt, qty]
+          )
+        end
+
+        result.map { |row| Message.new(row) }
+      end
+
       # Reads messages using grouped round-robin ordering
       #
       # Messages are grouped by the first key in their JSON payload and returned

--- a/lib/pgmq/client/consumer.rb
+++ b/lib/pgmq/client/consumer.rb
@@ -229,7 +229,7 @@ module PGMQ
 
       # Reads one message per FIFO group from the head of each group
       #
-      # Returns exactly one message — the oldest visible message — from each
+      # Returns exactly one message - the oldest visible message - from each
       # distinct FIFO group, up to qty groups. Groups are determined by the
       # `x-pgmq-group` key in the message headers (set via the `headers:` param
       # on `produce`). Messages without that header key all land in a single
@@ -237,7 +237,7 @@ module PGMQ
       #
       # Unlike `read_grouped` (which groups by the first payload key and drains
       # one group fully before moving to the next), `read_grouped_head` surfaces
-      # the leading edge of every group in one call — useful for detecting
+      # the leading edge of every group in one call - useful for detecting
       # head-of-line stalls or building per-group progress dashboards.
       #
       # @note Requires PGMQ v1.11.1+.

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -31,7 +31,7 @@ module PGMQ
       # connection is dead and a retry on a fresh socket is safe. Strings are
       # matched as case-insensitive substrings; Regexps match the original
       # message. The built-in LOST_CONNECTION_MESSAGES are always checked
-      # first — this list is appended to them.
+      # first - this list is appended to them.
       #
       # Thread-safe: reads are lock-free (frozen array swap); writes should
       # be done at boot time before forking workers.
@@ -43,7 +43,7 @@ module PGMQ
       attr_reader :reconnectable_error_patterns
 
       # Additional exception classes that mean the connection is dead.
-      # `PG::ConnectionBad` and `PG::UnableToSend` are always matched — this
+      # `PG::ConnectionBad` and `PG::UnableToSend` are always matched - this
       # list is appended to them. Subclasses also match.
       #
       # Thread-safe: reads are lock-free; writes should be done at boot time.
@@ -315,7 +315,7 @@ module PGMQ
               raise PGMQ::Errors::ConfigurationError,
                 "Connection callable returned the same PG::Connection object " \
                 "(object_id: #{conn.object_id}) to multiple pool slots. " \
-                "PG::Connection is NOT thread-safe — concurrent use causes nil results, " \
+                "PG::Connection is NOT thread-safe - concurrent use causes nil results, " \
                 "segfaults, and data corruption. Ensure your callable returns a unique " \
                 "PG::Connection instance on each invocation (for example, by calling " \
                 "PG.connect inside the callable)."

--- a/test/lib/pgmq/client/consumer_test.rb
+++ b/test/lib/pgmq/client/consumer_test.rb
@@ -546,7 +546,11 @@ describe PGMQ::Client::Consumer do
       assert_respond_to msg, :read_ct
       assert_respond_to msg, :enqueued_at
       assert_respond_to msg, :vt
+      assert_respond_to msg, :last_read_at
+      assert_respond_to msg, :headers
       assert_equal({ "val" => 99 }, JSON.parse(msg.message))
+      # x-pgmq-group header must survive the round-trip
+      assert_equal "g1", JSON.parse(msg.headers)["x-pgmq-group"]
     end
 
     it "returns exactly one message per x-pgmq-group header group" do
@@ -555,8 +559,10 @@ describe PGMQ::Client::Consumer do
       2.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header("group2")) }
 
       messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
+      groups = messages.map { |m| JSON.parse(m.headers)["x-pgmq-group"] }
 
       assert_equal 2, messages.size
+      assert_equal %w[group1 group2].sort, groups.sort
     end
 
     it "respects the qty limit — caps the number of groups sampled" do
@@ -565,8 +571,10 @@ describe PGMQ::Client::Consumer do
       end
 
       messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 3)
+      groups = messages.map { |m| JSON.parse(m.headers)["x-pgmq-group"] }
 
       assert_equal 3, messages.size
+      assert_equal 3, groups.uniq.size
     end
 
     it "reads fewer than qty when fewer groups exist" do
@@ -574,8 +582,10 @@ describe PGMQ::Client::Consumer do
       @client.produce(@queue_name, to_json_msg({ seq: 0 }), headers: group_header("gb"))
 
       messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
+      groups = messages.map { |m| JSON.parse(m.headers)["x-pgmq-group"] }
 
       assert_equal 2, messages.size
+      assert_equal %w[ga gb].sort, groups.sort
     end
 
     it "returns the head (oldest) message from each group" do

--- a/test/lib/pgmq/client/consumer_test.rb
+++ b/test/lib/pgmq/client/consumer_test.rb
@@ -516,6 +516,123 @@ describe PGMQ::Client::Consumer do
     end
   end
 
+  describe "#read_grouped_head" do
+    # Groups are determined by the x-pgmq-group key in message headers.
+    # Messages without that header all land in a single implicit default group.
+    def group_header(name)
+      { "x-pgmq-group" => name }.to_json
+    end
+
+    it "returns an empty array for an empty queue" do
+      assert_equal [], @client.read_grouped_head(@queue_name, vt: 30, qty: 5)
+    end
+
+    it "returns PGMQ::Message objects" do
+      @client.produce(@queue_name, to_json_msg({ seq: 1 }), headers: group_header("g1"))
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 1)
+
+      assert_equal 1, messages.size
+      assert_kind_of PGMQ::Message, messages.first
+    end
+
+    it "returns all expected message fields" do
+      @client.produce(@queue_name, to_json_msg({ val: 99 }), headers: group_header("g1"))
+
+      msg = @client.read_grouped_head(@queue_name, vt: 30, qty: 1).first
+
+      assert_respond_to msg, :msg_id
+      assert_respond_to msg, :message
+      assert_respond_to msg, :read_ct
+      assert_respond_to msg, :enqueued_at
+      assert_respond_to msg, :vt
+      assert_equal({ "val" => 99 }, JSON.parse(msg.message))
+    end
+
+    it "returns exactly one message per x-pgmq-group header group" do
+      # group1 has 3 messages, group2 has 2 — should get one from each
+      3.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header("group1")) }
+      2.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header("group2")) }
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
+
+      assert_equal 2, messages.size
+    end
+
+    it "respects the qty limit — caps the number of groups sampled" do
+      %w[a b c d e].each do |g|
+        2.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header(g)) }
+      end
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 3)
+
+      assert_equal 3, messages.size
+    end
+
+    it "reads fewer than qty when fewer groups exist" do
+      @client.produce(@queue_name, to_json_msg({ seq: 0 }), headers: group_header("ga"))
+      @client.produce(@queue_name, to_json_msg({ seq: 0 }), headers: group_header("gb"))
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
+
+      assert_equal 2, messages.size
+    end
+
+    it "returns the head (oldest) message from each group" do
+      @client.produce(@queue_name, to_json_msg({ seq: 1 }), headers: group_header("g1"))
+      @client.produce(@queue_name, to_json_msg({ seq: 2 }), headers: group_header("g1"))
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 5)
+
+      # Only one message per group, and it must be the oldest (seq: 1)
+      assert_equal 1, messages.size
+      assert_equal 1, JSON.parse(messages.first.message)["seq"]
+    end
+
+    it "messages without x-pgmq-group header all share one default group" do
+      # Without headers, all messages land in the implicit default group
+      3.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i })) }
+
+      messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
+
+      # All in the same default group — only 1 returned
+      assert_equal 1, messages.size
+    end
+
+    it "respects visibility timeout — message hidden during vt" do
+      @client.produce(@queue_name, to_json_msg({ seq: 1 }), headers: group_header("g1"))
+
+      first = @client.read_grouped_head(@queue_name, vt: 2, qty: 1)
+
+      assert_equal 1, first.size
+
+      second = @client.read_grouped_head(@queue_name, vt: 2, qty: 1)
+
+      assert_empty second
+
+      sleep 2.5
+
+      third = @client.read_grouped_head(@queue_name, vt: 30, qty: 1)
+
+      assert_equal 1, third.size
+      assert_equal first.first.msg_id, third.first.msg_id
+    end
+
+    it "validates the queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.read_grouped_head("bad queue!", vt: 30, qty: 1)
+      end
+    end
+
+    it "uses DEFAULT_VT when vt not specified" do
+      @client.produce(@queue_name, to_json_msg({ seq: 1 }), headers: group_header("g1"))
+
+      messages = @client.read_grouped_head(@queue_name, qty: 1)
+
+      assert_equal 1, messages.size
+    end
+  end
+
   describe "#read_grouped_rr" do
     it "reads messages in round-robin order across groups" do
       # Send messages from different "users" (grouped by first key value)

--- a/test/lib/pgmq/client/consumer_test.rb
+++ b/test/lib/pgmq/client/consumer_test.rb
@@ -277,7 +277,7 @@ describe PGMQ::Client::Consumer do
       assert_equal 2, messages.size
     end
 
-    it "respects visibility timeout — message hidden during vt" do
+    it "respects visibility timeout - message hidden during vt" do
       @client.produce(@queue_name, to_json_msg({ user_id: "u1" }))
 
       first = @client.read_grouped(@queue_name, vt: 2, qty: 1)
@@ -297,7 +297,7 @@ describe PGMQ::Client::Consumer do
     end
 
     it "drains the oldest group first (SQS-style throughput ordering)" do
-      # user1 has 3 messages, user2 has 1 — requesting qty: 3 should drain user1 first
+      # user1 has 3 messages, user2 has 1 - requesting qty: 3 should drain user1 first
       @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 1 }))
       @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 2 }))
       @client.produce(@queue_name, to_json_msg({ user_id: "user1", seq: 3 }))
@@ -307,7 +307,7 @@ describe PGMQ::Client::Consumer do
 
       assert_equal 3, messages.size
       user_ids = messages.map { |m| JSON.parse(m.message)["user_id"] }
-      # All 3 should be from user1 — oldest group drained first
+      # All 3 should be from user1 - oldest group drained first
       assert_equal ["user1"] * 3, user_ids
     end
 
@@ -554,7 +554,7 @@ describe PGMQ::Client::Consumer do
     end
 
     it "returns exactly one message per x-pgmq-group header group" do
-      # group1 has 3 messages, group2 has 2 — should get one from each
+      # group1 has 3 messages, group2 has 2 - should get one from each
       3.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header("group1")) }
       2.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header("group2")) }
 
@@ -565,7 +565,7 @@ describe PGMQ::Client::Consumer do
       assert_equal %w[group1 group2].sort, groups.sort
     end
 
-    it "respects the qty limit — caps the number of groups sampled" do
+    it "respects the qty limit - caps the number of groups sampled" do
       %w[a b c d e].each do |g|
         2.times { |i| @client.produce(@queue_name, to_json_msg({ seq: i }), headers: group_header(g)) }
       end
@@ -605,11 +605,11 @@ describe PGMQ::Client::Consumer do
 
       messages = @client.read_grouped_head(@queue_name, vt: 30, qty: 10)
 
-      # All in the same default group — only 1 returned
+      # All in the same default group - only 1 returned
       assert_equal 1, messages.size
     end
 
-    it "respects visibility timeout — message hidden during vt" do
+    it "respects visibility timeout - message hidden during vt" do
       @client.produce(@queue_name, to_json_msg({ seq: 1 }), headers: group_header("g1"))
 
       first = @client.read_grouped_head(@queue_name, vt: 2, qty: 1)

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -314,7 +314,7 @@ describe PGMQ::Connection do
     end
 
     it "matches PG::UnableToSend by class" do
-      # Raised by libpq when the write side of the connection is gone —
+      # Raised by libpq when the write side of the connection is gone -
       # another dedicated connection-failure class.
       error = PG::UnableToSend.new("")
 


### PR DESCRIPTION
## Summary

- Add `read_grouped_head(queue_name, vt:, qty:)` — returns the oldest visible message from each distinct FIFO group, up to `qty` groups
- Groups are identified by the `x-pgmq-group` key in message **headers** (set via `headers:` on `produce`); messages without that header all share one implicit default group
- Unlike `read_grouped` (which groups by the first payload key and drains one group fully before the next), `read_grouped_head` surfaces the leading edge of every group in a single call — ideal for head-of-line stall detection and per-group progress dashboards
- Requires PGMQ v1.11.1+

## Test plan

- [ ] Empty queue returns `[]`
- [ ] Returns `PGMQ::Message` objects with all expected fields
- [ ] Returns exactly one message per `x-pgmq-group` header group
- [ ] Respects `qty` cap — limits number of groups sampled
- [ ] Reads fewer than `qty` when fewer groups exist
- [ ] Returns the oldest (head) message from each group, not a later one
- [ ] Messages without `x-pgmq-group` header all share one default group (only 1 returned)
- [ ] Respects visibility timeout — message hidden during VT, visible again after expiry
- [ ] Validates queue name (raises `InvalidQueueNameError`)
- [ ] Uses `DEFAULT_VT` when `vt:` not specified