### PR TITLE
chore: reflow YARD prose to 120-char lines; replace em dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers
-- **[Feature]** Add `read_grouped_head(queue_name, vt:, qty:)` — reads exactly one message (the
+- **[Feature]** Add `read_grouped_head(queue_name, vt:, qty:)` - reads exactly one message (the
   oldest visible) from each distinct FIFO group, up to `qty` groups. Groups are identified by the
   `x-pgmq-group` key in message headers (set via `headers:` on `produce`); messages without that
   header all share one implicit default group. Unlike `read_grouped` (which groups by the first
   payload key and drains one group fully before moving on), `read_grouped_head` surfaces the
-  leading edge of every group in a single call — ideal for detecting head-of-line stalls or
+  leading edge of every group in a single call - ideal for detecting head-of-line stalls or
   building per-group progress dashboards. Requires PGMQ v1.11.1+.
 - **[Feature]** Add SQS-style grouped reading:
-  - `read_grouped(queue_name, vt:, qty:)` — reads messages grouped by the first JSON key,
+  - `read_grouped(queue_name, vt:, qty:)` - reads messages grouped by the first JSON key,
     filling the batch from the oldest group first (throughput-optimised). Contrast with
     `read_grouped_rr` which interleaves groups fairly.
-  - `read_grouped_with_poll(queue_name, vt:, qty:, max_poll_seconds:, poll_interval_ms:)` —
+  - `read_grouped_with_poll(queue_name, vt:, qty:, max_poll_seconds:, poll_interval_ms:)` -
     same strategy with long-polling support.
 
   Use `read_grouped` when maximising throughput matters more than fairness across groups
@@ -52,7 +52,7 @@
 ### Infrastructure
 - **[Change]** Migrate test framework from RSpec to Minitest/Spec with Mocha for mocking, aligning with the broader Karafka ecosystem conventions.
 - **[Change]** Replace `rubocop-rspec` with `rubocop-minitest` for test linting.
-- **[Change]** Add `bin/integrations` runner script that centralizes integration spec execution. Specs no longer need `require_relative "support/example_helper"` — the runner injects it via `-r` flag. Run all specs with `bin/integrations` or specific ones with `bin/integrations spec/integration/foo_spec.rb`.
+- **[Change]** Add `bin/integrations` runner script that centralizes integration spec execution. Specs no longer need `require_relative "support/example_helper"` - the runner injects it via `-r` flag. Run all specs with `bin/integrations` or specific ones with `bin/integrations spec/integration/foo_spec.rb`.
 
 ## 0.5.0 (2026-02-24)
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ PGMQ::Connection.reconnectable_error_patterns = [
 PGMQ::Connection.reconnectable_error_classes = [PG::ConnectionRefused]
 ```
 
-The built-in defaults are always kept — your patterns and classes are
+The built-in defaults are always kept - your patterns and classes are
 appended to them. Configuration errors (e.g. passing an Integer as a
 pattern) raise `PGMQ::Errors::ConfigurationError` immediately so
 misconfiguration can't silently disable retries.
@@ -323,7 +323,7 @@ misconfiguration can't silently disable retries.
 > **Reserve these options for connection-level failures.** A "reconnectable"
 > error means the socket is dead and a retry on a fresh connection is safe.
 > Do **not** add patterns or classes for query-level errors (deadlocks,
-> constraint violations, statement timeouts) — those will replay your
+> constraint violations, statement timeouts) - those will replay your
 > operation against a healthy connection and may cause duplicate work or
 > mask bugs.
 
@@ -489,7 +489,7 @@ Drains the oldest group completely before moving to the next. Best when maximisi
 ```ruby
 # Queue: user_a has 3 messages, user_b has 1
 messages = client.read_grouped("tasks", vt: 30, qty: 3)
-# => [user_a_1, user_a_2, user_a_3]  — drains user_a first
+# => [user_a_1, user_a_2, user_a_3]  - drains user_a first
 
 # With long-polling (waits up to max_poll_seconds if queue is empty)
 messages = client.read_grouped_with_poll("tasks",
@@ -502,7 +502,7 @@ messages = client.read_grouped_with_poll("tasks",
 
 ##### Round-Robin (`read_grouped_rr` / `read_grouped_rr_with_poll`)
 
-Interleaves one message per group on each pass. Best for fairness — prevents any single entity from monopolising workers:
+Interleaves one message per group on each pass. Best for fairness - prevents any single entity from monopolising workers:
 
 ```ruby
 # Queue: user_a: 5 messages, user_b: 2, user_c: 1
@@ -520,15 +520,15 @@ messages = client.read_grouped_rr_with_poll("tasks",
 
 **Message format for payload-based grouping** (used by `read_grouped` and `read_grouped_rr`):
 ```ruby
-# user_id is first key — PGMQ uses it as the group identifier
+# user_id is first key - PGMQ uses it as the group identifier
 client.produce("tasks", '{"user_id":"user_a","task":"process"}')
 ```
 
-##### Head-of-Group (`read_grouped_head`) — PGMQ v1.11.1+
+##### Head-of-Group (`read_grouped_head`) - PGMQ v1.11.1+
 
 Returns the oldest visible message from each FIFO group, up to `qty` groups. Groups are identified by the `x-pgmq-group` key in the message **headers**. Messages without that header all share one implicit default group.
 
-Useful for detecting head-of-line stalls or building per-group progress dashboards — one call surfaces the leading edge of every group simultaneously:
+Useful for detecting head-of-line stalls or building per-group progress dashboards - one call surfaces the leading edge of every group simultaneously:
 
 ```ruby
 # Produce with x-pgmq-group headers

--- a/lib/pgmq.rb
+++ b/lib/pgmq.rb
@@ -12,9 +12,8 @@ loader.eager_load
 
 # PGMQ - Low-level Ruby client for Postgres Message Queue
 #
-# This is a low-level library providing direct access to PGMQ operations.
-# For higher-level abstractions, job processing, and framework integrations,
-# see pgmq-framework (similar to how rdkafka-ruby relates to Karafka).
+# This is a low-level library providing direct access to PGMQ operations. For higher-level abstractions, job processing,
+# and framework integrations, see pgmq-framework (similar to how rdkafka-ruby relates to Karafka).
 #
 # @example Basic usage
 #   require 'pgmq'

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -3,8 +3,8 @@
 module PGMQ
   # Low-level client for interacting with PGMQ (Postgres Message Queue)
   #
-  # This is a thin wrapper around PGMQ SQL functions. For higher-level
-  # abstractions (job processing, retries, Rails integration), use pgmq-framework.
+  # This is a thin wrapper around PGMQ SQL functions. For higher-level abstractions (job processing, retries, Rails
+  # integration), use pgmq-framework.
   #
   # @example Basic usage
   #   client = PGMQ::Client.new(
@@ -114,9 +114,8 @@ module PGMQ
         )
       end
 
-      # PGMQ creates tables with prefixes (pgmq.q_<name>, pgmq.a_<name>)
-      # PostgreSQL has a 63-character limit for identifiers, but PGMQ enforces 48
-      # to account for prefixes and potential suffixes
+      # PGMQ creates tables with prefixes (pgmq.q_<name>, pgmq.a_<name>). PostgreSQL has a 63-character limit for
+      # identifiers, but PGMQ enforces 48 to account for prefixes and potential suffixes.
       if queue_name.to_s.length >= 48
         raise(
           Errors::InvalidQueueNameError,
@@ -125,8 +124,7 @@ module PGMQ
         )
       end
 
-      # PostgreSQL identifier rules: start with letter or underscore,
-      # contain only letters, digits, underscores
+      # PostgreSQL identifier rules: start with letter or underscore, contain only letters, digits, underscores
       return if queue_name.to_s.match?(/\A[a-zA-Z_][a-zA-Z0-9_]*\z/)
 
       raise(

--- a/lib/pgmq/client/consumer.rb
+++ b/lib/pgmq/client/consumer.rb
@@ -4,8 +4,8 @@ module PGMQ
   class Client
     # Single-queue message reading operations
     #
-    # This module handles reading messages from a single queue, including basic reads,
-    # batch reads, and long-polling for efficient message consumption.
+    # This module handles reading messages from a single queue, including basic reads, batch reads, and long-polling for
+    # efficient message consumption.
     module Consumer
       # Reads a message from the queue
       #
@@ -153,11 +153,9 @@ module PGMQ
 
       # Reads messages using SQS-style grouped ordering (throughput-optimised)
       #
-      # Messages are grouped by the first key in their JSON payload. Unlike
-      # round-robin, this strategy fills the requested batch from the oldest
-      # group first, then moves on to the next group only when the first is
-      # exhausted. Maximises throughput for bursty workloads at the cost of
-      # fairness across groups.
+      # Messages are grouped by the first key in their JSON payload. Unlike round-robin, this strategy fills the
+      # requested batch from the oldest group first, then moves on to the next group only when the first is exhausted.
+      # Maximises throughput for bursty workloads at the cost of fairness across groups.
       #
       # @param queue_name [String] name of the queue
       # @param vt [Integer] visibility timeout in seconds
@@ -190,9 +188,8 @@ module PGMQ
 
       # Reads messages using SQS-style grouped ordering with long-polling support
       #
-      # Combines SQS-style throughput-first grouped ordering with long-polling.
-      # Blocks up to max_poll_seconds if the queue is empty, returning as soon
-      # as any message arrives.
+      # Combines SQS-style throughput-first grouped ordering with long-polling. Blocks up to max_poll_seconds if the
+      # queue is empty, returning as soon as any message arrives.
       #
       # @param queue_name [String] name of the queue
       # @param vt [Integer] visibility timeout in seconds
@@ -229,15 +226,13 @@ module PGMQ
 
       # Reads one message per FIFO group from the head of each group
       #
-      # Returns exactly one message - the oldest visible message - from each
-      # distinct FIFO group, up to qty groups. Groups are determined by the
-      # `x-pgmq-group` key in the message headers (set via the `headers:` param
-      # on `produce`). Messages without that header key all land in a single
-      # implicit default group, so only one of them is returned per call.
+      # Returns exactly one message - the oldest visible message - from each distinct FIFO group, up to qty groups.
+      # Groups are determined by the `x-pgmq-group` key in the message headers (set via the `headers:` param on
+      # `produce`). Messages without that header key all land in a single implicit default group, so only one of them is
+      # returned per call.
       #
-      # Unlike `read_grouped` (which groups by the first payload key and drains
-      # one group fully before moving to the next), `read_grouped_head` surfaces
-      # the leading edge of every group in one call - useful for detecting
+      # Unlike `read_grouped` (which groups by the first payload key and drains one group fully before moving to the
+      # next), `read_grouped_head` surfaces the leading edge of every group in one call - useful for detecting
       # head-of-line stalls or building per-group progress dashboards.
       #
       # @note Requires PGMQ v1.11.1+.
@@ -274,9 +269,8 @@ module PGMQ
 
       # Reads messages using grouped round-robin ordering
       #
-      # Messages are grouped by the first key in their JSON payload and returned
-      # in round-robin order across groups. This ensures fair processing when
-      # messages from different entities (users, orders, etc.) are in the queue.
+      # Messages are grouped by the first key in their JSON payload and returned in round-robin order across groups.
+      # This ensures fair processing when messages from different entities (users, orders, etc.) are in the queue.
       #
       # @param queue_name [String] name of the queue
       # @param vt [Integer] visibility timeout in seconds
@@ -309,8 +303,7 @@ module PGMQ
 
       # Reads messages using grouped round-robin with long-polling support
       #
-      # Combines grouped round-robin ordering with long-polling for efficient
-      # and fair message consumption.
+      # Combines grouped round-robin ordering with long-polling for efficient and fair message consumption.
       #
       # @param queue_name [String] name of the queue
       # @param vt [Integer] visibility timeout in seconds

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -4,8 +4,7 @@ module PGMQ
   class Client
     # Queue maintenance operations
     #
-    # This module handles queue maintenance tasks such as purging messages
-    # and detaching archive tables.
+    # This module handles queue maintenance tasks such as purging messages and detaching archive tables.
     module Maintenance
       # Purges all messages from a queue
       #
@@ -27,9 +26,8 @@ module PGMQ
 
       # Enables PostgreSQL NOTIFY when messages are inserted into a queue
       #
-      # When enabled, PostgreSQL will send a NOTIFY event on message insert,
-      # allowing clients to use LISTEN instead of polling. The throttle interval
-      # prevents notification storms during high-volume inserts.
+      # When enabled, PostgreSQL will send a NOTIFY event on message insert, allowing clients to use LISTEN instead of
+      # polling. The throttle interval prevents notification storms during high-volume inserts.
       #
       # @param queue_name [String] name of the queue
       # @param throttle_interval_ms [Integer] minimum ms between notifications (default: 250)

--- a/lib/pgmq/client/message_lifecycle.rb
+++ b/lib/pgmq/client/message_lifecycle.rb
@@ -4,8 +4,8 @@ module PGMQ
   class Client
     # Message lifecycle operations (pop, delete, archive, visibility timeout)
     #
-    # This module handles message state transitions including popping (atomic read+delete),
-    # deleting, archiving, and updating visibility timeouts.
+    # This module handles message state transitions including popping (atomic read+delete), deleting, archiving, and
+    # updating visibility timeouts.
     module MessageLifecycle
       # Pops a message (atomic read + delete)
       #
@@ -104,8 +104,8 @@ module PGMQ
 
       # Deletes specific messages from multiple queues in a single transaction
       #
-      # Efficiently deletes messages across different queues atomically.
-      # Useful when processing related messages from different queues.
+      # Efficiently deletes messages across different queues atomically. Useful when processing related messages from
+      # different queues.
       #
       # @param deletions [Hash] hash of queue_name => array of msg_ids
       # @return [Hash] hash of queue_name => array of deleted msg_ids
@@ -307,9 +307,8 @@ module PGMQ
 
       # Updates visibility timeout for messages across multiple queues in a single transaction
       #
-      # Efficiently updates visibility timeouts across different queues atomically.
-      # Useful when processing related messages from different queues and needing
-      # to extend their visibility timeouts together.
+      # Efficiently updates visibility timeouts across different queues atomically. Useful when processing related
+      # messages from different queues and needing to extend their visibility timeouts together.
       #
       # Supports two modes:
       # - Integer offset (seconds from now): `vt: 60` - messages visible in 60 seconds

--- a/lib/pgmq/client/metrics.rb
+++ b/lib/pgmq/client/metrics.rb
@@ -4,8 +4,7 @@ module PGMQ
   class Client
     # Queue metrics and monitoring
     #
-    # This module handles retrieving queue metrics such as queue length,
-    # message age, and total message counts.
+    # This module handles retrieving queue metrics such as queue length, message age, and total message counts.
     module Metrics
       # Gets metrics for a specific queue
       #

--- a/lib/pgmq/client/multi_queue.rb
+++ b/lib/pgmq/client/multi_queue.rb
@@ -4,13 +4,13 @@ module PGMQ
   class Client
     # Multi-queue operations
     #
-    # This module handles efficient operations across multiple queues using single
-    # database queries with UNION ALL for optimal performance.
+    # This module handles efficient operations across multiple queues using single database queries with UNION ALL for
+    # optimal performance.
     module MultiQueue
       # Reads from multiple queues in a single query
       #
-      # This is the most efficient way to monitor multiple queues with a single
-      # database connection. Uses UNION ALL to read from all queues in one query.
+      # This is the most efficient way to monitor multiple queues with a single database connection. Uses UNION ALL to
+      # read from all queues in one query.
       #
       # @param queue_names [Array<String>] array of queue names to read from
       # @param vt [Integer] visibility timeout in seconds
@@ -53,8 +53,7 @@ module PGMQ
         # Validate all queue names (prevents SQL injection)
         queue_names.each { |qn| validate_queue_name!(qn) }
 
-        # Build UNION ALL query for all queues
-        # Note: Queue names are validated, so this is safe from SQL injection
+        # Build UNION ALL query for all queues. Note: Queue names are validated, so this is safe from SQL injection.
         union_queries = queue_names.map do |queue_name|
           # Escape single quotes in queue name (though validation should prevent this)
           escaped_name = queue_name.gsub("'", "''")
@@ -76,9 +75,8 @@ module PGMQ
 
       # Reads from multiple queues with long-polling (waits for messages)
       #
-      # Efficiently polls multiple queues waiting for the first available message.
-      # This uses a single connection with periodic polling until a message arrives
-      # or the timeout is reached.
+      # Efficiently polls multiple queues waiting for the first available message. This uses a single connection with
+      # periodic polling until a message arrives or the timeout is reached.
       #
       # @param queue_names [Array<String>] array of queue names to poll
       # @param vt [Integer] visibility timeout in seconds
@@ -144,8 +142,8 @@ module PGMQ
 
       # Pops a message from multiple queues (atomic read + delete)
       #
-      # Efficiently gets and immediately deletes the first available message from
-      # any of the specified queues. Uses a single query with UNION ALL.
+      # Efficiently gets and immediately deletes the first available message from any of the specified queues. Uses a
+      # single query with UNION ALL.
       #
       # @param queue_names [Array<String>] array of queue names
       # @return [PGMQ::Message, nil] message with queue_name attribute, or nil if no messages

--- a/lib/pgmq/client/producer.rb
+++ b/lib/pgmq/client/producer.rb
@@ -4,8 +4,8 @@ module PGMQ
   class Client
     # Message producing operations
     #
-    # This module handles producing messages to queues, both individual messages
-    # and batches. Users must serialize messages to JSON strings themselves.
+    # This module handles producing messages to queues, both individual messages and batches. Users must serialize
+    # messages to JSON strings themselves.
     module Producer
       # Produces a message to a queue
       #

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -4,8 +4,8 @@ module PGMQ
   class Client
     # Queue management operations (create, drop, list)
     #
-    # This module handles all queue lifecycle operations including creating queues
-    # (standard, partitioned, unlogged), dropping queues, and listing existing queues.
+    # This module handles all queue lifecycle operations including creating queues (standard, partitioned, unlogged),
+    # dropping queues, and listing existing queues.
     module QueueManagement
       # Creates a new queue
       #

--- a/lib/pgmq/client/topics.rb
+++ b/lib/pgmq/client/topics.rb
@@ -4,8 +4,8 @@ module PGMQ
   class Client
     # Topic routing operations (AMQP-like patterns)
     #
-    # This module provides AMQP-style topic routing for PGMQ, allowing messages
-    # to be routed to multiple queues based on pattern matching.
+    # This module provides AMQP-style topic routing for PGMQ, allowing messages to be routed to multiple queues based on
+    # pattern matching.
     #
     # Topic patterns support wildcards:
     # - `*` matches exactly one word between dots (e.g., `orders.*` matches `orders.new`)
@@ -15,8 +15,7 @@ module PGMQ
     module Topics
       # Binds a topic pattern to a queue
       #
-      # Messages sent with routing keys matching this pattern will be delivered
-      # to the specified queue.
+      # Messages sent with routing keys matching this pattern will be delivered to the specified queue.
       #
       # @param pattern [String] topic pattern with optional wildcards (* or #)
       # @param queue_name [String] name of the queue to bind
@@ -66,8 +65,7 @@ module PGMQ
 
       # Sends a message via topic routing
       #
-      # The message will be delivered to all queues whose bound patterns match
-      # the routing key.
+      # The message will be delivered to all queues whose bound patterns match the routing key.
       #
       # @param routing_key [String] dot-separated routing key (e.g., "orders.new.priority")
       # @param message [String] message as JSON string
@@ -108,8 +106,7 @@ module PGMQ
 
       # Sends multiple messages via topic routing
       #
-      # All messages will be delivered to all queues whose bound patterns match
-      # the routing key.
+      # All messages will be delivered to all queues whose bound patterns match the routing key.
       #
       # @param routing_key [String] dot-separated routing key
       # @param messages [Array<String>] array of message payloads as JSON strings
@@ -230,8 +227,8 @@ module PGMQ
 
       # Validates a routing key
       #
-      # Routing keys are dot-separated words (no wildcards allowed).
-      # Returns false for invalid routing keys (PGMQ raises an error for invalid keys).
+      # Routing keys are dot-separated words (no wildcards allowed). Returns false for invalid routing keys (PGMQ raises
+      # an error for invalid keys).
       #
       # @param routing_key [String] routing key to validate
       # @return [Boolean] true if valid, false if invalid

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -27,14 +27,11 @@ module PGMQ
     DEFAULT_POOL_TIMEOUT = 5
 
     class << self
-      # Additional error message patterns (String or Regexp) that mean the
-      # connection is dead and a retry on a fresh socket is safe. Strings are
-      # matched as case-insensitive substrings; Regexps match the original
-      # message. The built-in LOST_CONNECTION_MESSAGES are always checked
-      # first - this list is appended to them.
+      # Additional error message patterns (String or Regexp) that mean the connection is dead and a retry on a fresh
+      # socket is safe. Strings are matched as case-insensitive substrings; Regexps match the original message. The
+      # built-in LOST_CONNECTION_MESSAGES are always checked first - this list is appended to them.
       #
-      # Thread-safe: reads are lock-free (frozen array swap); writes should
-      # be done at boot time before forking workers.
+      # Thread-safe: reads are lock-free (frozen array swap); writes should be done at boot time before forking workers.
       #
       # @return [Array<String, Regexp>]
       # @example
@@ -42,9 +39,8 @@ module PGMQ
       #   PGMQ::Connection.reconnectable_error_patterns << /\Abroken pipe\b/i
       attr_reader :reconnectable_error_patterns
 
-      # Additional exception classes that mean the connection is dead.
-      # `PG::ConnectionBad` and `PG::UnableToSend` are always matched - this
-      # list is appended to them. Subclasses also match.
+      # Additional exception classes that mean the connection is dead. `PG::ConnectionBad` and `PG::UnableToSend` are
+      # always matched - this list is appended to them. Subclasses also match.
       #
       # Thread-safe: reads are lock-free; writes should be done at boot time.
       #
@@ -73,9 +69,8 @@ module PGMQ
 
       # Normalizes user-supplied reconnectable error patterns.
       #
-      # Strings are downcased once at configuration time so the hot path
-      # (`connection_lost_error?`) only does substring checks. Regexps are
-      # passed through unchanged.
+      # Strings are downcased once at configuration time so the hot path (`connection_lost_error?`) only does substring
+      # checks. Regexps are passed through unchanged.
       #
       # @param patterns [Array<String, Regexp>, String, Regexp, nil]
       # @return [Array<String, Regexp>]
@@ -198,11 +193,9 @@ module PGMQ
 
     private
 
-    # Messages libpq raises when the server/pooler has already torn down the
-    # socket. The list has grown organically with each pooler/TLS variant we
-    # see in the wild; the class check below catches future variants that
-    # libpq raises as `PG::ConnectionBad` or `PG::UnableToSend` without
-    # waiting for a new message to hit production.
+    # Messages libpq raises when the server/pooler has already torn down the socket. The list has grown organically with
+    # each pooler/TLS variant we see in the wild; the class check below catches future variants that libpq raises as
+    # `PG::ConnectionBad` or `PG::UnableToSend` without waiting for a new message to hit production.
     LOST_CONNECTION_MESSAGES = [
       "server closed the connection",
       "connection not open",
@@ -220,13 +213,10 @@ module PGMQ
 
     # Checks if the error indicates a lost connection.
     #
-    # Matches in three steps: first by class (`PG::ConnectionBad` /
-    # `PG::UnableToSend` are dedicated connection-failure classes libpq
-    # raises regardless of message, plus any user-supplied classes), then
-    # by built-in message substrings for the bare `PG::Error` cases where
-    # libpq doesn't reach for the specific subclass, and finally by
-    # user-supplied patterns (strings matched as case-insensitive
-    # substrings, Regexps matched against the original message).
+    # Matches in three steps: first by class (`PG::ConnectionBad` / `PG::UnableToSend` are dedicated connection-failure
+    # classes libpq raises regardless of message, plus any user-supplied classes), then by built-in message substrings
+    # for the bare `PG::Error` cases where libpq doesn't reach for the specific subclass, and finally by user-supplied
+    # patterns (strings matched as case-insensitive substrings, Regexps matched against the original message).
     #
     # @param error [PG::Error] the error to check
     # @return [Boolean] true if the connection was lost and a retry on a
@@ -252,11 +242,9 @@ module PGMQ
 
     # Verifies a connection is alive and working.
     #
-    # Also resets when the connection reports `PG::CONNECTION_BAD`, which
-    # happens when the server (or an intermediate pooler such as PgBouncer)
-    # has closed the socket while the client-side `PG::Connection` object
-    # still exists. `#finished?` alone only catches connections closed
-    # explicitly from the client side.
+    # Also resets when the connection reports `PG::CONNECTION_BAD`, which happens when the server (or an intermediate
+    # pooler such as PgBouncer) has closed the socket while the client-side `PG::Connection` object still exists.
+    # `#finished?` alone only catches connections closed explicitly from the client side.
     #
     # @param conn [PG::Connection] connection to verify
     # @raise [PG::Error] if the reset itself fails
@@ -306,9 +294,8 @@ module PGMQ
       ConnectionPool.new(size: @pool_size, timeout: @pool_timeout) do
         conn = create_connection(params)
 
-        # Detect shared connections: if a callable returns the same PG::Connection
-        # object to multiple pool slots, concurrent use will corrupt libpq state
-        # (nil results, segfaults, wrong data). Fail fast with a clear message.
+        # Detect shared connections: if a callable returns the same PG::Connection object to multiple pool slots,
+        # concurrent use will corrupt libpq state (nil results, segfaults, wrong data). Fail fast with a clear message.
         if conn.is_a?(PG::Connection)
           seen_mutex.synchronize do
             if seen_connections.key?(conn)
@@ -338,10 +325,10 @@ module PGMQ
       # If we have a callable (e.g., for Rails), call it to get the connection
       return params.call if params.respond_to?(:call)
 
-      # Create new connection from parameters
-      # Low-level library: return all values as strings from PostgreSQL
-      # No automatic type conversion - let higher-level frameworks handle parsing
-      # conn.type_map_for_results intentionally NOT set
+      # Create new connection from parameters.
+      # Low-level library: return all values as strings from PostgreSQL.
+      # No automatic type conversion - let higher-level frameworks handle parsing.
+      # conn.type_map_for_results intentionally NOT set.
       PG.connect(params[:conninfo] || params)
     rescue PG::Error => e
       raise PGMQ::Errors::ConnectionError, "Failed to connect to database: #{e.message}"

--- a/lib/pgmq/message.rb
+++ b/lib/pgmq/message.rb
@@ -3,8 +3,8 @@
 module PGMQ
   # Represents a message read from a PGMQ queue
   #
-  # Returns raw values from PostgreSQL without transformation.
-  # Higher-level frameworks should handle parsing, deserialization, etc.
+  # Returns raw values from PostgreSQL without transformation. Higher-level frameworks should handle parsing,
+  # deserialization, etc.
   #
   # @example Reading a message (raw values)
   #   msg = client.read("my_queue", vt: 30)
@@ -24,9 +24,8 @@ module PGMQ
       # @param row [Hash] database row from PG result
       # @return [Message]
       def new(row, **)
-        # Return raw values as-is from PostgreSQL
-        # No parsing, no deserialization, no transformation
-        # The pg gem returns JSONB as String by default
+        # Return raw values as-is from PostgreSQL. No parsing, no deserialization, no transformation.
+        # The pg gem returns JSONB as String by default.
         super(
           msg_id: row["msg_id"],
           read_ct: row["read_ct"],

--- a/lib/pgmq/transaction.rb
+++ b/lib/pgmq/transaction.rb
@@ -3,12 +3,11 @@
 module PGMQ
   # Low-level transaction support for PGMQ operations
   #
-  # Provides atomic execution of PGMQ operations within PostgreSQL transactions.
-  # Transactions are a database primitive - this is a thin wrapper around
-  # PostgreSQL's native transaction support.
+  # Provides atomic execution of PGMQ operations within PostgreSQL transactions. Transactions are a database primitive -
+  # this is a thin wrapper around PostgreSQL's native transaction support.
   #
-  # This is analogous to rdkafka-ruby providing Kafka transaction support -
-  # it's a protocol/database feature, not a framework abstraction.
+  # This is analogous to rdkafka-ruby providing Kafka transaction support - it's a protocol/database feature, not a
+  # framework abstraction.
   #
   # @example Atomic multi-queue operations
   #   client.transaction do |txn|
@@ -24,8 +23,8 @@ module PGMQ
   module Transaction
     # Executes PGMQ operations atomically within a database transaction
     #
-    # Obtains a connection from the pool, starts a transaction, and yields
-    # a client that uses that transaction for all operations.
+    # Obtains a connection from the pool, starts a transaction, and yields a client that uses that transaction for all
+    # operations.
     #
     # @yield [PGMQ::Client] transactional client using the same connection
     # @return [Object] result of the block


### PR DESCRIPTION
## Summary

- Replace em dashes (`—`) with regular hyphens (`-`) throughout `CHANGELOG.md`, `README.md`, and all `lib/**/*.rb` files
- Reflow prose comment paragraphs in `lib/**/*.rb` to fill up to the 120-character line limit defined in `.rubocop.yml`, matching the Karafka/Waterdrop style where comment lines are kept dense rather than wrapping at ~70 chars

## What's preserved

- `@param`, `@return`, `@example`, `@note` and all other YARD tags — not touched
- Code examples inside `@example` blocks — not touched
- List items (`-`/`*`) — not touched
- Directive comments (`# frozen_string_literal`, `# rubocop:`) — not touched

## Test plan

- [ ] All 320 unit tests pass (`bundle exec rake test`)
- [ ] Line coverage remains at 97.21%
- [ ] No YARD tag or code example was reflowed (spot-check `consumer.rb`, `connection.rb`)