### PR TITLE
Feature: add create_fifo_index and create_fifo_indexes_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.7.0 (Unreleased)
 
+### Queue Management
+- **[Feature]** Add `create_fifo_index(queue_name)` - creates the FIFO index on a queue's underlying table required
+  for correct ordering and acceptable performance with grouped read operations (`read_grouped`, `read_grouped_rr`,
+  `read_grouped_head`). The operation is idempotent.
+- **[Feature]** Add `create_fifo_indexes_all` - convenience wrapper that creates FIFO indexes on every queue
+  registered in `pgmq.meta`. Useful for one-time migrations when adding grouped reads to an existing deployment.
+
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers
 - **[Feature]** Add `read_grouped_head(queue_name, vt:, qty:)` - reads exactly one message (the

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | **Queue Management** | `create` | Create standard queue | ✅ |
 | | `create_partitioned` | Create partitioned queue (requires pg_partman) | ✅ |
 | | `create_unlogged` | Create unlogged queue (faster, no crash recovery) | ✅ |
+| | `create_fifo_index` | Create FIFO index required for grouped reads | ✅ |
+| | `create_fifo_indexes_all` | Create FIFO indexes on all existing queues | ✅ |
 | | `drop_queue` | Delete queue and all messages | ✅ |
 | **Topic Routing** | `bind_topic` | Bind topic pattern to queue (AMQP-like) | ✅ |
 | | `unbind_topic` | Remove topic binding | ✅ |
@@ -355,6 +357,13 @@ client.create_unlogged("queue_name")  # => true/false
 
 # Drop queue (returns true if dropped, false if didn't exist)
 client.drop_queue("queue_name")  # => true/false
+
+# Create the FIFO index required for grouped reads (read_grouped, read_grouped_rr, read_grouped_head)
+# Idempotent - safe to call on a queue that already has the index
+client.create_fifo_index("queue_name")
+
+# Create FIFO indexes for all existing queues at once (useful for migrating an existing deployment)
+client.create_fifo_indexes_all
 
 # List all queues
 queues = client.list_queues

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -94,6 +94,49 @@ module PGMQ
         result[0]["drop_queue"] == "t"
       end
 
+      # Creates the FIFO index on a queue's table required for grouped reads
+      #
+      # Grouped read operations (`read_grouped`, `read_grouped_rr`, `read_grouped_head`) rely on this index for correct
+      # ordering and acceptable query performance. Without it, grouped reads will work but may be slow or return
+      # incorrect ordering at scale. The operation is idempotent - calling it on a queue that already has the index is
+      # safe.
+      #
+      # @param queue_name [String] name of the queue
+      # @return [void]
+      # @raise [PGMQ::Errors::InvalidQueueNameError] if queue name is invalid
+      # @raise [PGMQ::Errors::ConnectionError] if database operation fails
+      #
+      # @example
+      #   client.create("tasks")
+      #   client.create_fifo_index("tasks")
+      def create_fifo_index(queue_name)
+        validate_queue_name!(queue_name)
+
+        with_connection do |conn|
+          conn.exec_params("SELECT pgmq.create_fifo_index($1::text)", [queue_name])
+        end
+
+        nil
+      end
+
+      # Creates FIFO indexes on all existing queues
+      #
+      # Convenience wrapper that calls `create_fifo_index` for every queue registered in `pgmq.meta`. Useful for
+      # one-time migrations when adding grouped reads to an existing deployment. The operation is idempotent.
+      #
+      # @return [void]
+      # @raise [PGMQ::Errors::ConnectionError] if database operation fails
+      #
+      # @example Migrate an existing deployment to use grouped reads
+      #   client.create_fifo_indexes_all
+      def create_fifo_indexes_all
+        with_connection do |conn|
+          conn.exec("SELECT pgmq.create_fifo_indexes_all()")
+        end
+
+        nil
+      end
+
       # Lists all queues
       #
       # @return [Array<PGMQ::QueueMetadata>] array of queue metadata objects

--- a/test/lib/pgmq/client/queue_management_test.rb
+++ b/test/lib/pgmq/client/queue_management_test.rb
@@ -201,4 +201,55 @@ describe PGMQ::Client::QueueManagement do
       @client.drop_queue(queue2)
     end
   end
+
+  describe "#create_fifo_index" do
+    it "creates the FIFO index on a queue and returns nil" do
+      @client.create(@queue_name)
+
+      result = @client.create_fifo_index(@queue_name)
+
+      assert_nil result
+    end
+
+    it "is idempotent - calling twice does not raise" do
+      @client.create(@queue_name)
+      @client.create_fifo_index(@queue_name)
+
+      result = @client.create_fifo_index(@queue_name)
+
+      assert_nil result
+    end
+
+    it "raises for invalid queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.create_fifo_index("123invalid")
+      end
+    end
+  end
+
+  describe "#create_fifo_indexes_all" do
+    it "creates FIFO indexes for all queues and returns nil" do
+      queue1 = unique_queue_name("fifo1")
+      queue2 = unique_queue_name("fifo2")
+
+      @client.create(queue1)
+      @client.create(queue2)
+
+      result = @client.create_fifo_indexes_all
+
+      assert_nil result
+
+      @client.drop_queue(queue1)
+      @client.drop_queue(queue2)
+    end
+
+    it "is idempotent - calling twice does not raise" do
+      @client.create(@queue_name)
+      @client.create_fifo_indexes_all
+
+      result = @client.create_fifo_indexes_all
+
+      assert_nil result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds two wrappers for FIFO index management needed for correct and performant grouped read operations.

- **`create_fifo_index(queue_name)`** - creates the FIFO index on a single queue's underlying table. Without this index, `read_grouped`, `read_grouped_rr`, and `read_grouped_head` work but may return incorrect ordering or be slow at scale. Idempotent.
- **`create_fifo_indexes_all`** - convenience wrapper that creates the FIFO index on every queue registered in `pgmq.meta`. Useful for one-time migration of existing deployments before enabling grouped reads. Idempotent.

Both methods return `nil` (the underlying SQL function returns `void`).

## Test plan

- [ ] `create_fifo_index` creates index and returns nil
- [ ] `create_fifo_index` is idempotent (calling twice does not raise)
- [ ] `create_fifo_index` raises `InvalidQueueNameError` for invalid names
- [ ] `create_fifo_indexes_all` creates indexes for all queues and returns nil
- [ ] `create_fifo_indexes_all` is idempotent
- [ ] All 325 tests pass, coverage at 97.26%