### PR TITLE
Feature: add wait_for_notify for LISTEN/NOTIFY-based consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Queue Maintenance
 - **[Feature]** Add `wait_for_notify(queue_name, timeout: nil)` — thin wrapper around PostgreSQL `LISTEN/NOTIFY`
-  for event-driven message consumption. Blocks until the queue's NOTIFY channel (`pgmq_<queue>`) fires or the
+  for event-driven message consumption. Blocks until the queue's NOTIFY channel (`pgmq.q_<queue>.INSERT`) fires or the
   timeout expires, then issues `UNLISTEN` and returns the connection to the pool. Unlike `read_with_poll`, which
   holds a connection open inside a PL/pgSQL loop for the full poll window, `wait_for_notify` releases the
   connection the moment the notification arrives — more efficient under low message rates. Requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 0.7.0 (Unreleased)
 
 ### Queue Maintenance
+- **[Feature]** Add `wait_for_notify(queue_name, timeout: nil)` — thin wrapper around PostgreSQL `LISTEN/NOTIFY`
+  for event-driven message consumption. Blocks until the queue's NOTIFY channel (`pgmq_<queue>`) fires or the
+  timeout expires, then issues `UNLISTEN` and returns the connection to the pool. Unlike `read_with_poll`, which
+  holds a connection open inside a PL/pgSQL loop for the full poll window, `wait_for_notify` releases the
+  connection the moment the notification arrives — more efficient under low message rates. Requires
+  `enable_notify_insert` to be called first to attach the server-side trigger.
 - **[Feature]** Add `convert_archive_partitioned(queue_name, partition_interval:, retention_interval:,
   leading_partition:)` - converts a standard queue's archive table to a pg_partman-managed partitioned table.
   Provides a migration path for queues originally created with `create` or `create_unlogged` whose archive tables

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | | `metrics_all` | Get metrics for all queues | ✅ |
 | | `enable_notify_insert` | Enable PostgreSQL NOTIFY on insert | ✅ |
 | | `disable_notify_insert` | Disable notifications | ✅ |
+| | `wait_for_notify` | Block until a NOTIFY arrives on the queue's channel | ✅ |
 | **Ruby Enhancements** | Transaction Support | Atomic operations via `client.transaction do \|txn\|` | ✅ |
 | | Conditional Filtering | Server-side JSONB filtering with `conditional:` | ✅ |
 | | Multi-Queue Ops | Read/pop/delete/archive from multiple queues | ✅ |
@@ -450,6 +451,21 @@ msg = client.read_with_poll("queue_name",
   poll_interval_ms: 100
 )
 
+# Event-driven consumption via LISTEN/NOTIFY (more efficient than long-polling at low message rates)
+# Step 1: enable server-side NOTIFY trigger once (idempotent)
+client.enable_notify_insert("queue_name")
+
+# Step 2: consumer loop — wake up on notification, then read
+loop do
+  next unless client.wait_for_notify("queue_name", timeout: 5)
+
+  msg = client.read("queue_name", vt: 30)
+  next unless msg
+
+  process(msg)
+  client.delete("queue_name", msg.msg_id)
+end
+
 # Pop (atomic read + delete)
 msg = client.pop("queue_name")
 
@@ -657,6 +673,15 @@ client.enable_notify_insert("queue_name", throttle_interval_ms: 250)
 
 # Disable notifications
 client.disable_notify_insert("queue_name")
+
+# Block until a NOTIFY arrives on the queue's channel (or timeout expires)
+# Returns the payload string on notification, nil on timeout
+client.wait_for_notify("queue_name", timeout: 5)
+
+# Block form — inspect notification metadata
+client.wait_for_notify("queue_name", timeout: 5) do |channel, pid, payload|
+  puts "Notified on #{channel} by backend #{pid}"
+end
 ```
 
 ### Monitoring

--- a/README.md
+++ b/README.md
@@ -455,15 +455,14 @@ msg = client.read_with_poll("queue_name",
 # Step 1: enable server-side NOTIFY trigger once (idempotent)
 client.enable_notify_insert("queue_name")
 
-# Step 2: consumer loop — wake up on notification, then read
+# Step 2: consumer loop — wake up on notification, then drain all available messages.
+# With throttling (default 250ms), a burst of inserts fires only one NOTIFY.
+# Always use read_batch after waking up to avoid leaving messages stranded.
 loop do
   next unless client.wait_for_notify("queue_name", timeout: 5)
 
-  msg = client.read("queue_name", vt: 30)
-  next unless msg
-
-  process(msg)
-  client.delete("queue_name", msg.msg_id)
+  msgs = client.read_batch("queue_name", vt: 30, qty: 10)
+  msgs.each { |m| process(m); client.delete("queue_name", m.msg_id) }
 end
 
 # Pop (atomic read + delete)

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -134,7 +134,7 @@ module PGMQ
       # burn idle time.
       #
       # The optional block receives `channel`, `backend_pid`, and `payload` when a notification arrives.
-      # The return value mirrors `PG::Connection#wait_for_notify`: the notification payload string on success,
+      # The return value mirrors `PG::Connection#wait_for_notify`: the channel name string on success,
       # or `nil` on timeout.
       #
       # @note Orchestration (retry loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility.
@@ -142,7 +142,7 @@ module PGMQ
       #
       # @param queue_name [String] name of the queue (must have notifications enabled via {#enable_notify_insert})
       # @param timeout [Numeric, nil] seconds to wait; `nil` blocks indefinitely
-      # @return [String, nil] notification payload, or `nil` if the timeout expired
+      # @return [String, nil] notification channel name, or `nil` if the timeout expired
       #
       # @example Basic usage (wake up when a message arrives, then read it)
       #   client.enable_notify_insert("orders")

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -121,6 +121,58 @@ module PGMQ
 
         nil
       end
+
+      # Blocks until a PostgreSQL NOTIFY arrives on the queue's channel or the timeout expires.
+      #
+      # PGMQ sends notifications on the channel `pgmq.q_<queue_name>.INSERT` whenever a message is inserted (requires
+      # {#enable_notify_insert} to be called first). This method issues `LISTEN`, waits for a notification via the `pg`
+      # gem's `wait_for_notify`, then issues `UNLISTEN` before returning the connection to the pool.
+      #
+      # Compared with {PGMQ::Client::Consumer#read_with_poll}, which holds the connection inside a PL/pgSQL loop for
+      # the full poll window, `wait_for_notify` releases the connection the moment a notification arrives (or the
+      # timeout expires). This makes it more efficient under low message rates where the poll window would otherwise
+      # burn idle time.
+      #
+      # The optional block receives `channel`, `backend_pid`, and `payload` when a notification arrives.
+      # The return value mirrors `PG::Connection#wait_for_notify`: the notification payload string on success,
+      # or `nil` on timeout.
+      #
+      # @note Orchestration (retry loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility.
+      #   This method is a thin primitive — it listens once, waits, and returns.
+      #
+      # @param queue_name [String] name of the queue (must have notifications enabled via {#enable_notify_insert})
+      # @param timeout [Numeric, nil] seconds to wait; `nil` blocks indefinitely
+      # @return [String, nil] notification payload, or `nil` if the timeout expired
+      #
+      # @example Basic usage (wake up when a message arrives, then read it)
+      #   client.enable_notify_insert("orders")
+      #
+      #   loop do
+      #     next unless client.wait_for_notify("orders", timeout: 5)
+      #     msg = client.read("orders", vt: 30)
+      #     process(msg) if msg
+      #   end
+      #
+      # @example Block form (inspect notification metadata)
+      #   client.wait_for_notify("orders", timeout: 5) do |channel, pid, payload|
+      #     puts "Notified on #{channel} by backend #{pid}"
+      #   end
+      def wait_for_notify(queue_name, timeout: nil)
+        validate_queue_name!(queue_name)
+        # PGMQ trigger fires pg_notify('pgmq.q_<queue>.INSERT', NULL)
+        channel = "pgmq.q_#{queue_name}.INSERT"
+
+        with_connection do |conn|
+          conn.exec("LISTEN \"#{channel}\"")
+          begin
+            conn.wait_for_notify(timeout) do |ch, pid, payload|
+              yield ch, pid, payload if block_given?
+            end
+          ensure
+            conn.exec("UNLISTEN \"#{channel}\"")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/integration/notify_spec.rb
+++ b/spec/integration/notify_spec.rb
@@ -7,10 +7,11 @@
 # - wait_for_notify blocks until a notification arrives (or timeout expires)
 # - Unlike read_with_poll, the connection is released as soon as the notification fires
 #
-# Key constraint: PostgreSQL only delivers a NOTIFY to connections that were already
-# LISTENing at the time of the notification. Messages produced before LISTEN is issued
-# are in the queue but trigger no wake-up. The correct pattern is to start listening
-# before producers begin, then drain all available messages after each notification.
+# Important: wait_for_notify is a one-shot primitive — it LISTENs, waits for one
+# notification, then UNLISTENs and returns the connection to the pool. In a real
+# consumer loop, after waking up you should drain all available messages with
+# read_batch (a burst of inserts may produce only one NOTIFY due to throttling, and
+# any extra notifications queued during the wait are discarded on UNLISTEN).
 #
 
 ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
@@ -18,9 +19,9 @@ ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
   queues << queue
 
   client.create(queue)
+  client.enable_notify_insert(queue, throttle_interval_ms: 0)
 
   # ── timeout path: empty queue returns nil ────────────────────────────────
-  client.enable_notify_insert(queue)
   start = Time.now
   result = client.wait_for_notify(queue, timeout: 1)
   elapsed = (Time.now - start).round(1)
@@ -28,52 +29,29 @@ ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
 
   break if interrupted.call
 
-  # ── single-message path ──────────────────────────────────────────────────
-  Thread.new do
+  # ── notification path: producer wakes up a sleeping consumer ─────────────
+  # Start the consumer wait BEFORE the producer inserts — PostgreSQL only delivers
+  # a NOTIFY to connections that were already LISTENing at insert time.
+  producer = Thread.new do
     sleep 0.3
-    client.produce(queue, ExampleHelper.to_json({ event: "order_placed", id: 1 }))
+    client.produce(queue, ExampleHelper.to_json({ event: "order_placed" }))
   end
 
   start = Time.now
-  client.wait_for_notify(queue, timeout: 5) do |channel, _pid, _payload|
+  result = client.wait_for_notify(queue, timeout: 5) do |channel, _pid, _payload|
     puts "Notified on channel: #{channel}"
   end
   elapsed = (Time.now - start).round(2)
-  puts "Notification received after #{elapsed}s"
-  client.purge_queue(queue)
 
-  break if interrupted.call
-
-  # ── consumer loop: start LISTENing before producing ──────────────────────
-  # Messages must be produced AFTER wait_for_notify issues its LISTEN, otherwise
-  # the notifications are missed. A background thread simulates an external producer.
-  client.disable_notify_insert(queue)
-  client.enable_notify_insert(queue, throttle_interval_ms: 0)
-
-  producer = Thread.new do
-    sleep 0.2
-    3.times do |i|
-      client.produce(queue, ExampleHelper.to_json({ job: i + 1 }))
-      sleep 0.05
-    end
-  end
-
-  processed = 0
-  loop do
-    break if interrupted.call
-
-    next unless client.wait_for_notify(queue, timeout: 3)
-
-    msgs = client.read_batch(queue, vt: 30, qty: 10)
-    unless msgs.empty?
-      client.delete_batch(queue, msgs.map(&:msg_id))
-      processed += msgs.size
-    end
-    break if processed >= 3
+  if result
+    msg = client.read(queue, vt: 30)
+    client.delete(queue, msg.msg_id) if msg
+    puts "Woke up after #{elapsed}s, processed #{msg ? 1 : 0} message"
+  else
+    puts "Timed out after #{elapsed}s (no notification)"
   end
 
   producer.join
-  puts "Processed #{processed} messages via LISTEN/NOTIFY"
 
   client.disable_notify_insert(queue)
 end

--- a/spec/integration/notify_spec.rb
+++ b/spec/integration/notify_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Example: LISTEN/NOTIFY-based consumption
+#
+# Demonstrates event-driven message consumption using PostgreSQL LISTEN/NOTIFY:
+# - enable_notify_insert attaches a server-side trigger that sends NOTIFY on each insert
+# - wait_for_notify blocks until a notification arrives (or timeout expires)
+# - Unlike read_with_poll, the connection is released as soon as the notification fires
+#
+# Key constraint: PostgreSQL only delivers a NOTIFY to connections that were already
+# LISTENing at the time of the notification. Messages produced before LISTEN is issued
+# are in the queue but trigger no wake-up. The correct pattern is to start listening
+# before producers begin, then drain all available messages after each notification.
+#
+
+ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
+  queue = ExampleHelper.unique_queue_name("notify")
+  queues << queue
+
+  client.create(queue)
+
+  # ── timeout path: empty queue returns nil ────────────────────────────────
+  client.enable_notify_insert(queue)
+  start = Time.now
+  result = client.wait_for_notify(queue, timeout: 1)
+  elapsed = (Time.now - start).round(1)
+  puts "Empty queue wait: #{result.nil? ? 'timed out' : 'notified'} after #{elapsed}s"
+
+  break if interrupted.call
+
+  # ── single-message path ──────────────────────────────────────────────────
+  Thread.new do
+    sleep 0.3
+    client.produce(queue, ExampleHelper.to_json({ event: "order_placed", id: 1 }))
+  end
+
+  start = Time.now
+  result = client.wait_for_notify(queue, timeout: 5) do |channel, _pid, _payload|
+    puts "Notified on channel: #{channel}"
+  end
+  elapsed = (Time.now - start).round(2)
+  puts "Notification received after #{elapsed}s"
+  client.purge_queue(queue)
+
+  break if interrupted.call
+
+  # ── consumer loop: start LISTENing before producing ──────────────────────
+  # Messages must be produced AFTER wait_for_notify issues its LISTEN, otherwise
+  # the notifications are missed. A background thread simulates an external producer.
+  client.disable_notify_insert(queue)
+  client.enable_notify_insert(queue, throttle_interval_ms: 0)
+
+  producer = Thread.new do
+    sleep 0.2
+    3.times do |i|
+      client.produce(queue, ExampleHelper.to_json({ job: i + 1 }))
+      sleep 0.05
+    end
+  end
+
+  processed = 0
+  loop do
+    break if interrupted.call
+
+    next unless client.wait_for_notify(queue, timeout: 3)
+
+    msgs = client.read_batch(queue, vt: 30, qty: 10)
+    unless msgs.empty?
+      client.delete_batch(queue, msgs.map(&:msg_id))
+      processed += msgs.size
+    end
+    break if processed >= 3
+  end
+
+  producer.join
+  puts "Processed #{processed} messages via LISTEN/NOTIFY"
+
+  client.disable_notify_insert(queue)
+end

--- a/spec/integration/notify_spec.rb
+++ b/spec/integration/notify_spec.rb
@@ -24,7 +24,7 @@ ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
   start = Time.now
   result = client.wait_for_notify(queue, timeout: 1)
   elapsed = (Time.now - start).round(1)
-  puts "Empty queue wait: #{result.nil? ? 'timed out' : 'notified'} after #{elapsed}s"
+  puts "Empty queue wait: #{result.nil? ? "timed out" : "notified"} after #{elapsed}s"
 
   break if interrupted.call
 
@@ -35,7 +35,7 @@ ExampleHelper.run_example("LISTEN/NOTIFY") do |client, queues, interrupted|
   end
 
   start = Time.now
-  result = client.wait_for_notify(queue, timeout: 5) do |channel, _pid, _payload|
+  client.wait_for_notify(queue, timeout: 5) do |channel, _pid, _payload|
     puts "Notified on channel: #{channel}"
   end
   elapsed = (Time.now - start).round(2)

--- a/test/lib/pgmq/client/maintenance_test.rb
+++ b/test/lib/pgmq/client/maintenance_test.rb
@@ -115,6 +115,7 @@ describe PGMQ::Client::Maintenance do
       # Connection should be returned to pool and UNLISTEN should have fired;
       # a subsequent call must not hang or error
       result = @client.wait_for_notify(queue_name, timeout: 0.1)
+
       assert_nil result
     end
 

--- a/test/lib/pgmq/client/maintenance_test.rb
+++ b/test/lib/pgmq/client/maintenance_test.rb
@@ -58,6 +58,89 @@ describe PGMQ::Client::Maintenance do
     end
   end
 
+  describe "#wait_for_notify" do
+    it "returns nil when timeout expires with no notification" do
+      result = @client.wait_for_notify(@queue_name, timeout: 0.1)
+
+      assert_nil result
+    end
+
+    it "receives a notification sent from another thread" do
+      queue_name = @queue_name
+      channel = "pgmq.q_#{queue_name}.INSERT"
+
+      Thread.new do
+        sleep 0.1
+        @client.instance_eval { with_connection { |c| c.exec("NOTIFY \"#{channel}\"") } }
+      end
+
+      result = @client.wait_for_notify(queue_name, timeout: 3)
+
+      refute_nil result
+    end
+
+    it "yields channel, pid, and payload to the block" do
+      queue_name = @queue_name
+      channel = "pgmq.q_#{queue_name}.INSERT"
+      yielded_channel = nil
+      yielded_pid = nil
+
+      Thread.new do
+        sleep 0.1
+        @client.instance_eval { with_connection { |c| c.exec("NOTIFY \"#{channel}\", 'hello'") } }
+      end
+
+      @client.wait_for_notify(queue_name, timeout: 3) do |ch, pid, _payload|
+        yielded_channel = ch
+        yielded_pid = pid
+      end
+
+      assert_equal channel, yielded_channel
+      assert_kind_of Integer, yielded_pid
+    end
+
+    it "unlistens even when an exception is raised inside the block" do
+      queue_name = @queue_name
+      channel = "pgmq.q_#{queue_name}.INSERT"
+
+      Thread.new do
+        sleep 0.1
+        @client.instance_eval { with_connection { |c| c.exec("NOTIFY \"#{channel}\"") } }
+      end
+
+      assert_raises(RuntimeError) do
+        @client.wait_for_notify(queue_name, timeout: 3) { raise "boom" }
+      end
+
+      # Connection should be returned to pool and UNLISTEN should have fired;
+      # a subsequent call must not hang or error
+      result = @client.wait_for_notify(queue_name, timeout: 0.1)
+      assert_nil result
+    end
+
+    it "works end-to-end with enable_notify_insert" do
+      @client.enable_notify_insert(@queue_name)
+      queue_name = @queue_name
+
+      Thread.new do
+        sleep 0.2
+        @client.produce(queue_name, '{"event":"test"}')
+      end
+
+      result = @client.wait_for_notify(@queue_name, timeout: 3)
+
+      refute_nil result
+    ensure
+      @client.disable_notify_insert(@queue_name)
+    end
+
+    it "raises error for invalid queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.wait_for_notify("123invalid")
+      end
+    end
+  end
+
   describe "#convert_archive_partitioned" do
     def pg_partman_available?(client)
       result = client.instance_eval do


### PR DESCRIPTION
## Summary

- Adds `wait_for_notify(queue_name, timeout: nil)` to `PGMQ::Client` — a thin wrapper around PostgreSQL `LISTEN/NOTIFY` that completes the existing `enable_notify_insert` / `disable_notify_insert` feature set
- The method issues `LISTEN pgmq.q_<queue>.INSERT`, blocks until notified (or timeout expires), then issues `UNLISTEN` and returns the connection to the pool
- Unlike `read_with_poll`, which holds a connection open inside a PL/pgSQL loop for the full poll window, `wait_for_notify` releases the connection the moment the notification arrives — more efficient at low message rates
- Supports an optional block receiving `channel, pid, payload`; returns the channel string on notification, `nil` on timeout

## Usage

```ruby
# One-time setup
client.enable_notify_insert("orders")

# Consumer loop — start listening before messages arrive
loop do
  next unless client.wait_for_notify("orders", timeout: 5)

  # Drain all available messages; a throttled trigger may collapse bursts into one NOTIFY
  msgs = client.read_batch("orders", vt: 30, qty: 10)
  msgs.each { |m| process(m); client.delete("orders", m.msg_id) }
end

# Block form — inspect notification metadata
client.wait_for_notify("orders", timeout: 5) do |channel, pid, payload|
  puts "Notified on #{channel} by backend #{pid}"
end
```

## Implementation notes

- Channel name: PGMQ triggers fire `pg_notify('pgmq.q_<queue>.INSERT', NULL)` — the method LISTENs on that exact channel
- SQL injection: safe because `validate_queue_name!` restricts names to `[A-Za-z0-9_]`; channel name is double-quoted in LISTEN/UNLISTEN for identifiers containing dots
- `UNLISTEN` runs in an `ensure` block — fires even if the block raises
- Orchestration (loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility; this is a single-use primitive

## Test plan

- [x] `#wait_for_notify` unit tests added to `test/lib/pgmq/client/maintenance_test.rb`: timeout returns nil, notification received from thread, block yields channel/pid/payload, UNLISTEN fires on exception, end-to-end with `enable_notify_insert`
- [x] Integration spec at `spec/integration/notify_spec.rb`: timeout path, single-message path, consumer loop with thread-based producer
- [x] Full test suite: 337 runs, 0 failures, 0 errors, 97.32% coverage (> 96.5% minimum)