### PR TITLE
Feature: add update_notify_insert for in-place throttle adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.7.0 (Unreleased)
 
 ### Queue Maintenance
+- **[Feature]** Add `update_notify_insert(queue_name, throttle_interval_ms:)` — updates the NOTIFY
+  throttle interval on an already-enabled trigger without having to disable and re-enable it.
+  Requires PGMQ v1.11.0+.
 - **[Feature]** Add `wait_for_notify(queue_name, timeout: nil)` — thin wrapper around PostgreSQL `LISTEN/NOTIFY`
   for event-driven message consumption. Blocks until the queue's NOTIFY channel (`pgmq.q_<queue>.INSERT`) fires or the
   timeout expires, then issues `UNLISTEN` and returns the connection to the pool. Unlike `read_with_poll`, which

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This gem provides complete support for all core PGMQ SQL functions. Based on the
 | | `metrics` | Get queue metrics (length, age, total messages) | ✅ |
 | | `metrics_all` | Get metrics for all queues | ✅ |
 | | `enable_notify_insert` | Enable PostgreSQL NOTIFY on insert | ✅ |
+| | `update_notify_insert` | Update throttle interval on an existing NOTIFY trigger | ✅ |
 | | `disable_notify_insert` | Disable notifications | ✅ |
 | | `wait_for_notify` | Block until a NOTIFY arrives on the queue's channel | ✅ |
 | **Ruby Enhancements** | Transaction Support | Atomic operations via `client.transaction do \|txn\|` | ✅ |
@@ -669,6 +670,9 @@ client.convert_archive_partitioned("queue_name",
 
 # Enable PostgreSQL NOTIFY for a queue (for LISTEN-based consumers)
 client.enable_notify_insert("queue_name", throttle_interval_ms: 250)
+
+# Update the throttle interval without disabling/re-enabling the trigger
+client.update_notify_insert("queue_name", throttle_interval_ms: 100)
 
 # Disable notifications
 client.disable_notify_insert("queue_name")

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,34 @@
+# TODO — pgmq-ruby gaps vs upstream
+
+## 1. Missing notification management methods
+
+Two functions from the NOTIFY family are not yet wrapped:
+
+- `list_notify_insert_throttles()` — returns all queues that have a NOTIFY trigger,
+  with their `throttle_interval_ms` and `last_notified_at`. Useful for inspecting
+  notification configuration across all queues at once.
+
+- ~~`update_notify_insert(queue_name, throttle_interval_ms)` — updates the throttle
+  interval on an already-enabled NOTIFY trigger without having to disable/re-enable.~~ ✓ Done
+
+Both were added in PGMQ v1.11.0. Existing neighbours in `lib/pgmq/client/maintenance.rb`:
+- `enable_notify_insert` ✓
+- `disable_notify_insert` ✓
+
+## 2. create_non_partitioned (minor)
+
+`pgmq.create_non_partitioned(queue_name)` is an explicit alias for the default `create()`
+behaviour. Provides symmetry with `create_partitioned` and `create_unlogged` for code
+that creates queue types generically. Low priority — `create()` already does the same thing.
+
+---
+
+## Resolved / Dropped
+
+- ✓ `read_grouped_head` — PR #121
+- ✓ `create_fifo_index` / `create_fifo_indexes_all` — PR #123
+- ✓ `convert_archive_partitioned` — PR #124
+- ✗ `read_grouped_head_with_poll` — does not exist in PGMQ v1.11.1 (confirmed not in
+  stable release or source). Dropped from watch list.
+- ✗ `detach_archive` — exists upstream but is a deprecated no-op scheduled for removal
+  in v2.0. Not worth wrapping.

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -105,6 +105,34 @@ module PGMQ
         nil
       end
 
+      # Updates the throttle interval for an already-enabled NOTIFY trigger
+      #
+      # Changes how frequently PostgreSQL is allowed to fire a NOTIFY event on message insert, without
+      # having to disable and re-enable the trigger. The queue must already have notifications enabled
+      # via {#enable_notify_insert}.
+      #
+      # @param queue_name [String] name of the queue
+      # @param throttle_interval_ms [Integer] new minimum ms between notifications
+      # @return [void]
+      #
+      # @example Tighten throttle to 100ms during high-throughput ingestion
+      #   client.update_notify_insert("orders", throttle_interval_ms: 100)
+      #
+      # @example Remove throttling entirely
+      #   client.update_notify_insert("orders", throttle_interval_ms: 0)
+      def update_notify_insert(queue_name, throttle_interval_ms:)
+        validate_queue_name!(queue_name)
+
+        with_connection do |conn|
+          conn.exec_params(
+            "SELECT pgmq.update_notify_insert($1::text, $2::integer)",
+            [queue_name, throttle_interval_ms]
+          )
+        end
+
+        nil
+      end
+
       # Disables PostgreSQL NOTIFY for a queue
       #
       # @param queue_name [String] name of the queue

--- a/test/lib/pgmq/client/maintenance_test.rb
+++ b/test/lib/pgmq/client/maintenance_test.rb
@@ -45,6 +45,24 @@ describe PGMQ::Client::Maintenance do
     end
   end
 
+  describe "#update_notify_insert" do
+    it "updates the throttle interval on an enabled notification trigger" do
+      @client.enable_notify_insert(@queue_name, throttle_interval_ms: 500)
+      @client.update_notify_insert(@queue_name, throttle_interval_ms: 100)
+    end
+
+    it "accepts zero to remove throttling" do
+      @client.enable_notify_insert(@queue_name)
+      @client.update_notify_insert(@queue_name, throttle_interval_ms: 0)
+    end
+
+    it "raises error for invalid queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.update_notify_insert("123invalid", throttle_interval_ms: 250)
+      end
+    end
+  end
+
   describe "#disable_notify_insert" do
     it "disables notifications on the queue" do
       @client.enable_notify_insert(@queue_name)


### PR DESCRIPTION
## Summary

- Wraps `pgmq.update_notify_insert()` added in PGMQ v1.11.0
- Lets callers change the NOTIFY throttle interval on an already-enabled trigger without the `disable_notify_insert` / `re-enable_notify_insert` round-trip
- Adds 3 tests (happy path, zero throttle, invalid queue name)
- Updates capability table and reference section in README
- Adds CHANGELOG entry under `0.7.0 (Unreleased)`

## Test plan

- [ ] All existing maintenance tests still pass
- [ ] `update_notify_insert` with standard interval succeeds
- [ ] `update_notify_insert` with `throttle_interval_ms: 0` succeeds (removes throttling)
- [ ] `update_notify_insert` with invalid queue name raises `PGMQ::Errors::InvalidQueueNameError`