### PR TITLE
feat(client): make with_connection public for non-PGMQ SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.7.0 (Unreleased)
 
+### Connection Management
+- **[Feature]** `PGMQ::Client#with_connection` is now public. Every PGMQ operation already checks
+  out a pooled, health-checked connection through this method; exposing it lets callers run
+  PostgreSQL statements PGMQ does not wrap (ad-hoc `NOTIFY`/`LISTEN`, advisory locks, custom
+  monitoring queries, DDL alongside queue tables) on the same pool instead of standing up a second
+  one. The yielded object is the raw `PG::Connection` (no type mapping, no implicit transaction);
+  use `client.transaction` when atomicity is required.
+
 ### Queue Maintenance
 - **[Feature]** Add `list_notify_insert_throttles` — returns an array of `PGMQ::NotifyThrottle`
   objects (one per queue with NOTIFY enabled), each carrying `queue_name`, `throttle_interval_ms`,

--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ You receive the raw `PG::Connection`: results come back as strings (no type
 mapping) and the statement is **not** wrapped in a transaction. Use
 [`client.transaction`](#transaction-support) when you need atomicity.
 
+> **Pool-safety caveats.** You're handed a *pooled* connection, so two rules apply:
+>
+> 1. **Don't keep the connection past the block.** Once the block returns, the
+>    connection goes back to the pool and another thread may check it out.
+>    `PG::Connection` is not thread-safe — using it afterwards can corrupt libpq
+>    state (nil results, wrong data, segfaults).
+> 2. **Clean up session state before the block exits.** The pool does *not* reset
+>    connections on check-in. A `LISTEN`, `SET`, session-level advisory lock
+>    (`pg_advisory_lock`), prepared statement, or temp table you create survives
+>    and leaks to the next pool user. Undo it (`UNLISTEN`, `RESET`,
+>    `pg_advisory_unlock`, …) before returning. For LISTEN/NOTIFY consumption,
+>    prefer `client.wait_for_notify`, which manages `LISTEN`/`UNLISTEN` for you.
+
 #### Extending the lost-connection error matchers
 
 PGMQ-Ruby ships with a curated list of `PG::Error` messages and classes

--- a/README.md
+++ b/README.md
@@ -299,6 +299,29 @@ client = PGMQ::Client.new(
 )
 ```
 
+#### Running custom SQL on the PGMQ pool
+
+Every PGMQ operation checks out a pooled connection through `client.with_connection`.
+The method is public, so you can run PostgreSQL statements PGMQ does not wrap
+without standing up a second connection pool. The connection is health-checked
+(when `auto_reconnect` is enabled) and returned to the pool when the block exits.
+
+```ruby
+# Fire a custom NOTIFY alongside your queues
+client.with_connection do |conn|
+  conn.exec_params("SELECT pg_notify($1, $2)", ["my_channel", payload])
+end
+
+# Run a monitoring query PGMQ does not wrap
+depth = client.with_connection do |conn|
+  conn.exec("SELECT count(*) FROM pgmq.q_orders")[0]["count"].to_i
+end
+```
+
+You receive the raw `PG::Connection`: results come back as strings (no type
+mapping) and the statement is **not** wrapped in a transaction. Use
+[`client.transaction`](#transaction-support) when you need atomicity.
+
 #### Extending the lost-connection error matchers
 
 PGMQ-Ruby ships with a curated list of `PG::Error` messages and classes

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -120,6 +120,16 @@ module PGMQ
     #
     # @note You receive the raw +PG::Connection+. PGMQ performs no type mapping (results come back as strings) and does
     #   not wrap your statement in a transaction. Use {#transaction} when you need atomicity.
+    #
+    # @note Do not retain or use the yielded connection outside the block. Once the block returns, the connection
+    #   goes back to the pool and another thread may check it out; +PG::Connection+ is not thread-safe, so using it
+    #   after the block can corrupt libpq state (nil results, wrong data, segfaults).
+    #
+    # @note The connection is returned to the pool *without* resetting session state. Anything session-scoped you
+    #   create - +LISTEN+, +SET+, a session-level advisory lock (+pg_advisory_lock+), a prepared statement, a temp
+    #   table - survives check-in and leaks to the next pool user. Undo it before the block exits (+UNLISTEN+,
+    #   +RESET+, +pg_advisory_unlock+, etc.). For LISTEN/NOTIFY consumption, prefer {#wait_for_notify}, which manages
+    #   +LISTEN+/+UNLISTEN+ for you.
     def with_connection(&)
       @connection.with_connection(&)
     end

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -93,14 +93,38 @@ module PGMQ
       @connection.stats
     end
 
-    private
-
-    # Executes a block with a database connection
-    # @yield [PG::Connection] database connection
-    # @return [Object] result of the block
+    # Checks out a pooled connection and yields the raw +PG::Connection+ for arbitrary SQL.
+    #
+    # All PGMQ operations run through this method internally, so it carries the same guarantees: a connection is taken
+    # from the pool, health-checked when +auto_reconnect+ is enabled, and a single retry on a fresh connection is
+    # attempted if the checked-out connection turns out to be dead before any SQL is sent (see
+    # {PGMQ::Connection#with_connection}). The connection is returned to the pool when the block exits.
+    #
+    # Exposed so callers can issue PostgreSQL statements PGMQ does not wrap without standing up a second pool: ad-hoc
+    # +NOTIFY+, +LISTEN+, advisory locks, custom monitoring queries, or DDL that lives alongside your queue tables.
+    # Reusing the PGMQ pool keeps connection accounting in one place.
+    #
+    # @yield [PG::Connection] a pooled, health-checked database connection
+    # @return [Object] the return value of the block
+    # @raise [PGMQ::Errors::ConnectionError] if a connection cannot be obtained
+    #
+    # @example Fire a custom NOTIFY on the PGMQ pool
+    #   client.with_connection do |conn|
+    #     conn.exec_params("SELECT pg_notify($1, $2)", ["my_channel", payload])
+    #   end
+    #
+    # @example Run a query PGMQ does not wrap
+    #   depth = client.with_connection do |conn|
+    #     conn.exec("SELECT count(*) FROM pgmq.q_orders")[0]["count"].to_i
+    #   end
+    #
+    # @note You receive the raw +PG::Connection+. PGMQ performs no type mapping (results come back as strings) and does
+    #   not wrap your statement in a transaction. Use {#transaction} when you need atomicity.
     def with_connection(&)
       @connection.with_connection(&)
     end
+
+    private
 
     # Validates a queue name
     # @param queue_name [String] queue name to validate

--- a/test/lib/pgmq/client_test.rb
+++ b/test/lib/pgmq/client_test.rb
@@ -36,6 +36,48 @@ describe PGMQ::Client do
     end
   end
 
+  describe "#with_connection" do
+    it "is a public method" do
+      assert_includes PGMQ::Client.public_instance_methods, :with_connection
+    end
+
+    it "yields a raw PG::Connection" do
+      @client.with_connection do |conn|
+        assert_kind_of PG::Connection, conn
+      end
+    end
+
+    it "returns the value of the block" do
+      result = @client.with_connection { |conn| conn.exec("SELECT 42 AS answer")[0]["answer"] }
+
+      assert_equal "42", result
+    end
+
+    it "supports SQL PGMQ does not wrap (custom NOTIFY)" do
+      result = @client.with_connection do |conn|
+        conn.exec_params("SELECT pg_notify($1, $2)", ["pgmq_ruby_test_channel", "ping"])
+      end
+
+      assert_equal 1, result.ntuples
+    end
+
+    it "checks the connection back into the pool after the block" do
+      before = @client.stats[:available]
+
+      @client.with_connection { |conn| conn.exec("SELECT 1") }
+
+      assert_equal before, @client.stats[:available]
+    end
+
+    it "propagates ConnectionError from the underlying pool" do
+      @client.connection.stubs(:with_connection).raises(PGMQ::Errors::ConnectionError, "boom")
+
+      assert_raises(PGMQ::Errors::ConnectionError) do
+        @client.with_connection { |_conn| :never }
+      end
+    end
+  end
+
   describe "#validate_queue_name!" do
     describe "valid queue names" do
       it "accepts simple lowercase names" do

--- a/test/lib/pgmq/client_test.rb
+++ b/test/lib/pgmq/client_test.rb
@@ -37,8 +37,9 @@ describe PGMQ::Client do
   end
 
   describe "#with_connection" do
-    it "is a public method" do
-      assert_includes PGMQ::Client.public_instance_methods, :with_connection
+    it "can be called publicly without __send__" do
+      # Regression guard: with_connection is part of the public API. A plain call must not raise NoMethodError.
+      assert_kind_of PG::Connection, @client.with_connection { |conn| conn }
     end
 
     it "yields a raw PG::Connection" do
@@ -61,11 +62,18 @@ describe PGMQ::Client do
       assert_equal 1, result.ntuples
     end
 
-    it "checks the connection back into the pool after the block" do
+    it "actually checks a connection out of the pool and returns it after the block" do
       before = @client.stats[:available]
 
-      @client.with_connection { |conn| conn.exec("SELECT 1") }
+      during = nil
+      @client.with_connection do |conn|
+        conn.exec("SELECT 1")
+        during = @client.stats[:available]
+      end
 
+      # Availability must dip while the block holds the connection, proving a real checkout (a no-op
+      # implementation that never checked one out would leave `during == before`), then recover afterwards.
+      assert_equal before - 1, during
       assert_equal before, @client.stats[:available]
     end
 


### PR DESCRIPTION
## Motivation

Every PGMQ operation already checks out a pooled, health-checked connection through `Client#with_connection` — but the method is `private`, so consumers who need to run a PostgreSQL statement PGMQ doesn't wrap (ad-hoc `NOTIFY`/`LISTEN`, advisory locks, custom monitoring queries, DDL that lives alongside the queue tables) have no way to reach the database without standing up a **second** connection pool.

In practice downstream code resorts to `client.__send__(:with_connection)` for things like fire-and-forget `pg_notify`. Making the method public turns that hack into a supported, documented escape hatch and keeps all connection accounting in one pool.

This fits the thin-wrapper philosophy: it exposes an existing internal primitive rather than adding framework behavior. (The gem already exposes LISTEN/NOTIFY via `wait_for_notify`.)

## What changed

- `PGMQ::Client#with_connection` is now **public**. It yields the raw, pooled, health-checked `PG::Connection` and returns it to the pool when the block exits.
- YARD docs + a README section under "Connection Pool Features".

## Pool-safety caveats (documented)

Because it yields a *pooled* connection, the docs spell out two rules:
1. **Don't retain the connection past the block** — it returns to the pool and another thread may use it; `PG::Connection` is not thread-safe.
2. **Clean up session state before the block exits** — `connection_pool` does not reset on check-in, so `LISTEN`/`SET`/session advisory locks/prepared statements/temp tables leak to the next pool user. For LISTEN/NOTIFY, prefer `wait_for_notify`, which manages `LISTEN`/`UNLISTEN`.

## Tests

6 new tests: yields a `PG::Connection`, returns the block value, runs non-PGMQ SQL (custom NOTIFY), checks a connection out of the pool (availability dips inside the block, recovers after) and propagates `ConnectionError`. Full suite green, lint clean.
