### PR TITLE
feat(queue): add opt-in autovacuum tuning for queue/archive tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@
   `read_grouped_head`). The operation is idempotent.
 - **[Feature]** Add `create_fifo_indexes_all` - convenience wrapper that creates FIFO indexes on every queue
   registered in `pgmq.meta`. Useful for one-time migrations when adding grouped reads to an existing deployment.
+- **[Feature]** Add `tune_autovacuum(queue_name, ...)` - sets per-table autovacuum storage parameters on a queue's
+  tables (`pgmq.q_<name>` and, unless `archive: false`, `pgmq.a_<name>`) via `ALTER TABLE`. PGMQ tables churn under
+  constant insert/update/delete, so PostgreSQL's default `autovacuum_vacuum_scale_factor` of 0.2 lets dead tuples
+  and index bloat accumulate before autovacuum runs. Defaults tighten the queue table to `scale_factor 0.01,
+  threshold 50` and the archive to `scale_factor 0.05, threshold 50`; all four are overridable. The numeric values
+  are coerced (`Float`/`Integer`) and the table name is quoted (`quote_ident`) before the `ALTER TABLE`. Opt-in:
+  the gem does not change storage parameters unless asked.
+- **[Feature]** `create`, `create_unlogged`, and `create_partitioned` accept a `tune_autovacuum:` keyword. Pass
+  `true` to apply the tuned defaults to the new queue's tables, or a Hash of the `tune_autovacuum` options. Defaults
+  to `false` (no change), preserving the thin-wrapper behaviour.
 
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers

--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ client.create_partitioned("queue_name",
 # Create unlogged queue (faster, no crash recovery)
 client.create_unlogged("queue_name")  # => true/false
 
+# Create a queue with autovacuum tuned for PGMQ's read+delete churn (see "Autovacuum Tuning")
+client.create("queue_name", tune_autovacuum: true)
+
 # Drop queue (returns true if dropped, false if didn't exist)
 client.drop_queue("queue_name")  # => true/false
 
@@ -402,6 +405,47 @@ client.create("my.queue")         # ✗ Contains period
 client.create("a" * 48)          # ✗ Too long (48+ chars)
 # Raises PGMQ::Errors::InvalidQueueNameError
 ```
+
+#### Autovacuum Tuning
+
+PGMQ tables churn in a way PostgreSQL's defaults are not tuned for: a hot queue
+inserts, updates (visibility timeout), and deletes rows constantly, so dead
+tuples pile up fast. With the default `autovacuum_vacuum_scale_factor` of `0.2`,
+autovacuum only runs once dead tuples reach 20% of the table — by which point a
+busy queue has bloated its heap and indexes, slowing every read. The archive
+table grows mostly by append, so it benefits from a gentler-but-still-tightened
+setting.
+
+`tune_autovacuum` sets per-table storage parameters via `ALTER TABLE`, so
+autovacuum runs far more often on *these specific tables* without touching
+cluster-wide settings. It is **opt-in** — the gem never mutates storage
+parameters unless you ask.
+
+```ruby
+# Tune an existing queue with PGMQ defaults:
+#   queue table   (pgmq.q_<name>): scale_factor 0.01, threshold 50
+#   archive table (pgmq.a_<name>): scale_factor 0.05, threshold 50
+client.tune_autovacuum("orders")
+
+# Override the queue setting and skip the archive table
+client.tune_autovacuum("orders", scale_factor: 0.005, archive: false)
+
+# Override every parameter
+client.tune_autovacuum("orders",
+  scale_factor: 0.01, threshold: 50,
+  archive_scale_factor: 0.05, archive_threshold: 50)
+
+# Or tune at creation time (true = defaults, or pass a Hash of the options above)
+client.create("orders", tune_autovacuum: true)
+client.create("orders", tune_autovacuum: { scale_factor: 0.005, archive: false })
+client.create_unlogged("fast", tune_autovacuum: true)
+client.create_partitioned("big", partition_interval: "daily",
+  retention_interval: "7 days", tune_autovacuum: true)
+```
+
+> **Partitioned queues:** parameters are set on the partitioned *parent* table.
+> PostgreSQL does not cascade storage parameters to existing partitions, so set
+> them per-partition if you need to retune already-created partitions.
 
 ### Sending Messages
 

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -34,6 +34,7 @@ module PGMQ
     include Maintenance          # Queue maintenance (purge, notifications)
     include Metrics              # Monitoring and metrics
     include Topics               # Topic routing (AMQP-like patterns, PGMQ v1.11.0+)
+    include Autovacuum           # Autovacuum tuning for queue/archive tables
 
     # Default visibility timeout in seconds
     DEFAULT_VT = 30

--- a/lib/pgmq/client/autovacuum.rb
+++ b/lib/pgmq/client/autovacuum.rb
@@ -69,8 +69,15 @@ module PGMQ
         validate_queue_name!(queue_name)
 
         with_connection do |conn|
-          alter_autovacuum(conn, "q_#{queue_name}", scale_factor, threshold)
-          alter_autovacuum(conn, "a_#{queue_name}", archive_scale_factor, archive_threshold) if archive
+          tune_autovacuum_on(
+            conn,
+            queue_name,
+            scale_factor: scale_factor,
+            threshold: threshold,
+            archive: archive,
+            archive_scale_factor: archive_scale_factor,
+            archive_threshold: archive_threshold
+          )
         end
 
         nil
@@ -78,7 +85,41 @@ module PGMQ
 
       private
 
+      # Resolves autovacuum options against the PGMQ-tuned defaults and applies them on an existing connection.
+      #
+      # Single source of truth for both entry points: {#tune_autovacuum} (which passes its keyword arguments through)
+      # and the +tune_autovacuum:+ creation flag (which passes a possibly-empty Hash). Keeping the default resolution
+      # and the archive-skip rule here means the two paths cannot drift - in particular, +archive+ is treated as a
+      # single truthiness test in one place rather than being checked differently per caller.
+      #
+      # @param conn [PG::Connection] the connection to run the ALTER TABLE statements on
+      # @param queue_name [String] name of the queue (already validated)
+      # @param opts [Hash] resolved or partial options; missing keys fall back to the DEFAULT_* constants
+      # @return [void]
+      def tune_autovacuum_on(conn, queue_name, opts = {})
+        alter_autovacuum(
+          conn,
+          "q_#{queue_name}",
+          opts.fetch(:scale_factor, DEFAULT_QUEUE_SCALE_FACTOR),
+          opts.fetch(:threshold, DEFAULT_QUEUE_THRESHOLD)
+        )
+
+        return unless opts.fetch(:archive, true)
+
+        alter_autovacuum(
+          conn,
+          "a_#{queue_name}",
+          opts.fetch(:archive_scale_factor, DEFAULT_ARCHIVE_SCALE_FACTOR),
+          opts.fetch(:archive_threshold, DEFAULT_ARCHIVE_THRESHOLD)
+        )
+      end
+
       # Issues a single ALTER TABLE setting the two autovacuum storage parameters on one pgmq table.
+      #
+      # PGMQ folds queue names to lower case when it creates the backing tables (`pgmq.create('MyQueue')` produces
+      # `pgmq.q_myqueue`), so the table name is lower-cased to match the physical table before it is quoted. Without
+      # this, a mixed-case queue name would build `q_MyQueue`, and +quote_ident+ would preserve that case and target
+      # a non-existent relation.
       #
       # Identifiers cannot be passed as bind parameters, so the table name is quoted with the connection's
       # +quote_ident+. The queue name has already passed {#validate_queue_name!} (strict identifier rules), and the
@@ -90,7 +131,7 @@ module PGMQ
       # @param threshold [Integer] autovacuum_vacuum_threshold
       # @return [void]
       def alter_autovacuum(conn, table, scale_factor, threshold)
-        qualified = "pgmq.#{conn.quote_ident(table)}"
+        qualified = "pgmq.#{conn.quote_ident(table.downcase)}"
 
         conn.exec(
           "ALTER TABLE #{qualified} SET (" \

--- a/lib/pgmq/client/autovacuum.rb
+++ b/lib/pgmq/client/autovacuum.rb
@@ -95,6 +95,11 @@ module PGMQ
       # @param conn [PG::Connection] the connection to run the ALTER TABLE statements on
       # @param queue_name [String] name of the queue (already validated)
       # @param opts [Hash] resolved or partial options; missing keys fall back to the DEFAULT_* constants
+      # @option opts [Float] :scale_factor queue table +autovacuum_vacuum_scale_factor+
+      # @option opts [Integer] :threshold queue table +autovacuum_vacuum_threshold+
+      # @option opts [Boolean] :archive also tune the archive table (default: true)
+      # @option opts [Float] :archive_scale_factor archive table +autovacuum_vacuum_scale_factor+
+      # @option opts [Integer] :archive_threshold archive table +autovacuum_vacuum_threshold+
       # @return [void]
       def tune_autovacuum_on(conn, queue_name, opts = {})
         alter_autovacuum(

--- a/lib/pgmq/client/autovacuum.rb
+++ b/lib/pgmq/client/autovacuum.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module PGMQ
+  class Client
+    # Autovacuum tuning for queue and archive tables.
+    #
+    # PGMQ tables churn in a way PostgreSQL's defaults are not tuned for: a hot queue inserts, updates (visibility
+    # timeout), and deletes rows constantly, so dead tuples accumulate fast. With the default
+    # +autovacuum_vacuum_scale_factor+ of 0.2, autovacuum only kicks in after dead tuples reach 20% of the table -
+    # by which point a busy queue has bloated its heap and indexes, slowing every read. The archive table grows
+    # monotonically (append + occasional prune), so it benefits from a gentler but still-tightened setting.
+    #
+    # This module applies per-table storage parameters via +ALTER TABLE+ so autovacuum runs far more often on these
+    # specific tables without touching cluster-wide settings. It is intentionally opt-in: the gem is a thin wrapper
+    # and does not mutate table storage parameters unless you ask it to (either by calling {#tune_autovacuum} or by
+    # passing +tune_autovacuum: true+ to a queue-creation method).
+    #
+    # @see https://www.postgresql.org/docs/current/runtime-config-autovacuum.html
+    module Autovacuum
+      # Aggressive scale factor for the active queue table. Triggers autovacuum once dead tuples reach 1% of the
+      # table (plus the threshold), keeping a hot queue's heap and indexes from bloating under read+delete churn.
+      DEFAULT_QUEUE_SCALE_FACTOR = 0.01
+
+      # Flat dead-tuple floor for the queue table, added to the scale-factor term. Keeps small queues from waiting on
+      # the percentage alone.
+      DEFAULT_QUEUE_THRESHOLD = 50
+
+      # Scale factor for the archive table. Archives grow mostly by append, so a looser factor than the queue is
+      # enough while still beating the 0.2 default.
+      DEFAULT_ARCHIVE_SCALE_FACTOR = 0.05
+
+      # Flat dead-tuple floor for the archive table.
+      DEFAULT_ARCHIVE_THRESHOLD = 50
+
+      # Tunes autovacuum storage parameters on a queue's underlying tables.
+      #
+      # Sets +autovacuum_vacuum_scale_factor+ and +autovacuum_vacuum_threshold+ on the queue table
+      # (+pgmq.q_<name>+) and, unless +archive: false+, on the archive table (+pgmq.a_<name>+). Existing PostgreSQL
+      # defaults for any other parameter are left untouched. Safe to call repeatedly - +ALTER TABLE ... SET+ is
+      # idempotent for a given value.
+      #
+      # @param queue_name [String] name of the queue
+      # @param scale_factor [Float] queue table +autovacuum_vacuum_scale_factor+
+      # @param threshold [Integer] queue table +autovacuum_vacuum_threshold+
+      # @param archive [Boolean] also tune the archive table (default: true)
+      # @param archive_scale_factor [Float] archive table +autovacuum_vacuum_scale_factor+
+      # @param archive_threshold [Integer] archive table +autovacuum_vacuum_threshold+
+      # @return [void]
+      # @raise [PGMQ::Errors::InvalidQueueNameError] if the queue name is invalid
+      # @raise [PGMQ::Errors::ConnectionError] if the database operation fails (e.g. the queue does not exist)
+      #
+      # @example Apply PGMQ-tuned defaults to an existing queue
+      #   client.tune_autovacuum("orders")
+      #
+      # @example Override the queue scale factor, skip the archive
+      #   client.tune_autovacuum("orders", scale_factor: 0.005, archive: false)
+      #
+      # @note On a partitioned queue or archive, the parameters are set on the parent table. PostgreSQL does not
+      #   cascade storage parameters to existing partitions, so pre-existing partitions keep their own settings;
+      #   set them per-partition if needed.
+      def tune_autovacuum(
+        queue_name,
+        scale_factor: DEFAULT_QUEUE_SCALE_FACTOR,
+        threshold: DEFAULT_QUEUE_THRESHOLD,
+        archive: true,
+        archive_scale_factor: DEFAULT_ARCHIVE_SCALE_FACTOR,
+        archive_threshold: DEFAULT_ARCHIVE_THRESHOLD
+      )
+        validate_queue_name!(queue_name)
+
+        with_connection do |conn|
+          alter_autovacuum(conn, "q_#{queue_name}", scale_factor, threshold)
+          alter_autovacuum(conn, "a_#{queue_name}", archive_scale_factor, archive_threshold) if archive
+        end
+
+        nil
+      end
+
+      private
+
+      # Issues a single ALTER TABLE setting the two autovacuum storage parameters on one pgmq table.
+      #
+      # Identifiers cannot be passed as bind parameters, so the table name is quoted with the connection's
+      # +quote_ident+. The queue name has already passed {#validate_queue_name!} (strict identifier rules), and the
+      # numeric values are coerced to Float/Integer, so no untrusted text reaches the statement.
+      #
+      # @param conn [PG::Connection] database connection
+      # @param table [String] unqualified table name (e.g. "q_orders")
+      # @param scale_factor [Float] autovacuum_vacuum_scale_factor
+      # @param threshold [Integer] autovacuum_vacuum_threshold
+      # @return [void]
+      def alter_autovacuum(conn, table, scale_factor, threshold)
+        qualified = "pgmq.#{conn.quote_ident(table)}"
+
+        conn.exec(
+          "ALTER TABLE #{qualified} SET (" \
+          "autovacuum_vacuum_scale_factor = #{Float(scale_factor)}, " \
+          "autovacuum_vacuum_threshold = #{Integer(threshold)})"
+        )
+      end
+    end
+  end
+end

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -194,6 +194,11 @@ module PGMQ
       # @param conn [PG::Connection] the connection the queue was created on
       # @param queue_name [String] name of the queue
       # @param option [Boolean, Hash] the tune_autovacuum option as passed to the create method
+      # @option option [Float] :scale_factor queue table +autovacuum_vacuum_scale_factor+
+      # @option option [Integer] :threshold queue table +autovacuum_vacuum_threshold+
+      # @option option [Boolean] :archive also tune the archive table (default: true)
+      # @option option [Float] :archive_scale_factor archive table +autovacuum_vacuum_scale_factor+
+      # @option option [Integer] :archive_threshold archive table +autovacuum_vacuum_threshold+
       # @return [void]
       def apply_tune_autovacuum_option(conn, queue_name, option)
         return unless option

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -10,6 +10,9 @@ module PGMQ
       # Creates a new queue
       #
       # @param queue_name [String] name of the queue to create
+      # @param tune_autovacuum [Boolean, Hash] when truthy, tune autovacuum on the new queue's tables after creation.
+      #   Pass +true+ for PGMQ-tuned defaults, or a Hash of options forwarded to {Autovacuum#tune_autovacuum}
+      #   (e.g. +{scale_factor: 0.005, archive: false}+). Defaults to +false+ (no change).
       # @return [Boolean] true if queue was created, false if it already existed
       # @raise [PGMQ::Errors::InvalidQueueNameError] if queue name is invalid
       # @raise [PGMQ::Errors::ConnectionError] if database operation fails
@@ -17,12 +20,16 @@ module PGMQ
       # @example
       #   client.create("orders")  # => true (created)
       #   client.create("orders")  # => false (already exists)
-      def create(queue_name)
+      #
+      # @example Create with tuned autovacuum
+      #   client.create("orders", tune_autovacuum: true)
+      def create(queue_name, tune_autovacuum: false)
         validate_queue_name!(queue_name)
 
         with_connection do |conn|
           existed = queue_exists?(conn, queue_name)
           conn.exec_params("SELECT pgmq.create($1::text)", [queue_name])
+          apply_tune_autovacuum_option(conn, queue_name, tune_autovacuum)
           !existed
         end
       end
@@ -34,6 +41,9 @@ module PGMQ
       # @param queue_name [String] name of the queue
       # @param partition_interval [String] partition interval (e.g., "daily", "10000")
       # @param retention_interval [String] retention interval (e.g., "7 days", "100000")
+      # @param tune_autovacuum [Boolean, Hash] when truthy, tune autovacuum on the new queue's tables after creation.
+      #   Pass +true+ for PGMQ-tuned defaults, or a Hash forwarded to {Autovacuum#tune_autovacuum}. Defaults to
+      #   +false+. Note: storage parameters are set on the partitioned parent and do not cascade to partitions.
       # @return [Boolean] true if queue was created, false if it already existed
       #
       # @example
@@ -44,7 +54,8 @@ module PGMQ
       def create_partitioned(
         queue_name,
         partition_interval: "10000",
-        retention_interval: "100000"
+        retention_interval: "100000",
+        tune_autovacuum: false
       )
         validate_queue_name!(queue_name)
 
@@ -54,6 +65,7 @@ module PGMQ
             "SELECT pgmq.create_partitioned($1::text, $2::text, $3::text)",
             [queue_name, partition_interval, retention_interval]
           )
+          apply_tune_autovacuum_option(conn, queue_name, tune_autovacuum)
           !existed
         end
       end
@@ -61,16 +73,20 @@ module PGMQ
       # Creates an unlogged queue for higher throughput (no crash recovery)
       #
       # @param queue_name [String] name of the queue
+      # @param tune_autovacuum [Boolean, Hash] when truthy, tune autovacuum on the new queue's tables after creation.
+      #   Pass +true+ for PGMQ-tuned defaults, or a Hash forwarded to {Autovacuum#tune_autovacuum}. Defaults to
+      #   +false+.
       # @return [Boolean] true if queue was created, false if it already existed
       #
       # @example
       #   client.create_unlogged("fast_queue")  # => true
-      def create_unlogged(queue_name)
+      def create_unlogged(queue_name, tune_autovacuum: false)
         validate_queue_name!(queue_name)
 
         with_connection do |conn|
           existed = queue_exists?(conn, queue_name)
           conn.exec_params("SELECT pgmq.create_unlogged($1::text)", [queue_name])
+          apply_tune_autovacuum_option(conn, queue_name, tune_autovacuum)
           !existed
         end
       end
@@ -165,6 +181,38 @@ module PGMQ
           [queue_name]
         )
         result.ntuples.positive?
+      end
+
+      # Applies the +tune_autovacuum:+ creation option on the create connection.
+      #
+      # Accepts the same shapes the create methods document: +false+/+nil+ (no-op), +true+ (PGMQ-tuned defaults), or a
+      # Hash of overrides forwarded to the same logic {Autovacuum#tune_autovacuum} uses. Runs on the connection that
+      # just created the queue so the ALTER TABLE shares that checkout rather than acquiring a second one.
+      #
+      # @param conn [PG::Connection] the connection the queue was created on
+      # @param queue_name [String] name of the queue
+      # @param option [Boolean, Hash] the tune_autovacuum option as passed to the create method
+      # @return [void]
+      def apply_tune_autovacuum_option(conn, queue_name, option)
+        return unless option
+
+        opts = option.is_a?(Hash) ? option : {}
+
+        alter_autovacuum(
+          conn,
+          "q_#{queue_name}",
+          opts.fetch(:scale_factor, Autovacuum::DEFAULT_QUEUE_SCALE_FACTOR),
+          opts.fetch(:threshold, Autovacuum::DEFAULT_QUEUE_THRESHOLD)
+        )
+
+        return if opts[:archive] == false
+
+        alter_autovacuum(
+          conn,
+          "a_#{queue_name}",
+          opts.fetch(:archive_scale_factor, Autovacuum::DEFAULT_ARCHIVE_SCALE_FACTOR),
+          opts.fetch(:archive_threshold, Autovacuum::DEFAULT_ARCHIVE_THRESHOLD)
+        )
       end
     end
   end

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -186,8 +186,10 @@ module PGMQ
       # Applies the +tune_autovacuum:+ creation option on the create connection.
       #
       # Accepts the same shapes the create methods document: +false+/+nil+ (no-op), +true+ (PGMQ-tuned defaults), or a
-      # Hash of overrides forwarded to the same logic {Autovacuum#tune_autovacuum} uses. Runs on the connection that
-      # just created the queue so the ALTER TABLE shares that checkout rather than acquiring a second one.
+      # Hash of overrides. Delegates resolution and the ALTER TABLE statements to {Autovacuum#tune_autovacuum_on}, the
+      # single source of truth shared with {Autovacuum#tune_autovacuum}, so defaults and the archive-skip rule cannot
+      # drift between the two paths. Runs on the connection that just created the queue, so the ALTER TABLE shares that
+      # checkout rather than acquiring a second one.
       #
       # @param conn [PG::Connection] the connection the queue was created on
       # @param queue_name [String] name of the queue
@@ -196,23 +198,7 @@ module PGMQ
       def apply_tune_autovacuum_option(conn, queue_name, option)
         return unless option
 
-        opts = option.is_a?(Hash) ? option : {}
-
-        alter_autovacuum(
-          conn,
-          "q_#{queue_name}",
-          opts.fetch(:scale_factor, Autovacuum::DEFAULT_QUEUE_SCALE_FACTOR),
-          opts.fetch(:threshold, Autovacuum::DEFAULT_QUEUE_THRESHOLD)
-        )
-
-        return if opts[:archive] == false
-
-        alter_autovacuum(
-          conn,
-          "a_#{queue_name}",
-          opts.fetch(:archive_scale_factor, Autovacuum::DEFAULT_ARCHIVE_SCALE_FACTOR),
-          opts.fetch(:archive_threshold, Autovacuum::DEFAULT_ARCHIVE_THRESHOLD)
-        )
+        tune_autovacuum_on(conn, queue_name, option.is_a?(Hash) ? option : {})
       end
     end
   end

--- a/test/lib/pgmq/client/autovacuum_test.rb
+++ b/test/lib/pgmq/client/autovacuum_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+describe PGMQ::Client::Autovacuum do
+  before do
+    @client = create_test_client
+    @queue_name = unique_queue_name
+  end
+
+  after { teardown_client_and_queue }
+
+  # Reads reloptions for a pgmq table (e.g. "q_<queue>" / "a_<queue>") as a Hash of String => String.
+  def reloptions(table)
+    result = @client.connection.with_connection do |conn|
+      conn.exec_params(
+        "SELECT unnest(reloptions) AS opt FROM pg_class WHERE relname = $1",
+        [table]
+      )
+    end
+
+    result.each_with_object({}) do |row, hash|
+      key, value = row["opt"].split("=", 2)
+      hash[key] = value
+    end
+  end
+
+  describe "#tune_autovacuum" do
+    before { @client.create(@queue_name) }
+
+    it "applies PGMQ-tuned defaults to the queue table" do
+      @client.tune_autovacuum(@queue_name)
+
+      opts = reloptions("q_#{@queue_name}")
+
+      assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "50", opts["autovacuum_vacuum_threshold"]
+    end
+
+    it "applies PGMQ-tuned defaults to the archive table" do
+      @client.tune_autovacuum(@queue_name)
+
+      opts = reloptions("a_#{@queue_name}")
+
+      assert_in_delta 0.05, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "50", opts["autovacuum_vacuum_threshold"]
+    end
+
+    it "honours custom scale factor and threshold on the queue table" do
+      @client.tune_autovacuum(@queue_name, scale_factor: 0.005, threshold: 25)
+
+      opts = reloptions("q_#{@queue_name}")
+
+      assert_in_delta 0.005, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "25", opts["autovacuum_vacuum_threshold"]
+    end
+
+    it "honours custom archive scale factor and threshold" do
+      @client.tune_autovacuum(@queue_name, archive_scale_factor: 0.02, archive_threshold: 100)
+
+      opts = reloptions("a_#{@queue_name}")
+
+      assert_in_delta 0.02, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "100", opts["autovacuum_vacuum_threshold"]
+    end
+
+    it "leaves the archive table untouched when archive: false" do
+      @client.tune_autovacuum(@queue_name, archive: false)
+
+      assert_empty reloptions("a_#{@queue_name}")
+    end
+
+    it "is idempotent" do
+      @client.tune_autovacuum(@queue_name)
+      @client.tune_autovacuum(@queue_name)
+
+      opts = reloptions("q_#{@queue_name}")
+
+      assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
+    end
+
+    it "returns nil" do
+      assert_nil @client.tune_autovacuum(@queue_name)
+    end
+
+    it "raises for an invalid queue name" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) do
+        @client.tune_autovacuum("123invalid")
+      end
+    end
+
+    it "raises ConnectionError for a non-existent queue" do
+      assert_raises(PGMQ::Errors::ConnectionError) do
+        @client.tune_autovacuum("nonexistent_queue_xyz")
+      end
+    end
+
+    it "coerces string-like numeric input safely" do
+      @client.tune_autovacuum(@queue_name, scale_factor: "0.03", threshold: "10")
+
+      opts = reloptions("q_#{@queue_name}")
+
+      assert_in_delta 0.03, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "10", opts["autovacuum_vacuum_threshold"]
+    end
+
+    it "rejects non-numeric scale factor rather than injecting it" do
+      assert_raises(ArgumentError) do
+        @client.tune_autovacuum(@queue_name, scale_factor: "0.01); DROP TABLE pgmq.meta; --")
+      end
+    end
+  end
+
+  describe "create with tune_autovacuum option" do
+    it "tunes both tables when create is called with tune_autovacuum: true" do
+      @client.create(@queue_name, tune_autovacuum: true)
+
+      assert_in_delta 0.01, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+      assert_in_delta 0.05, reloptions("a_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+    end
+
+    it "leaves tables untouched when create is called with the default (false)" do
+      @client.create(@queue_name)
+
+      assert_empty reloptions("q_#{@queue_name}")
+      assert_empty reloptions("a_#{@queue_name}")
+    end
+
+    it "forwards a Hash of options from create" do
+      @client.create(@queue_name, tune_autovacuum: { scale_factor: 0.002, archive: false })
+
+      assert_in_delta 0.002, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+      assert_empty reloptions("a_#{@queue_name}")
+    end
+
+    it "tunes when create_unlogged is called with tune_autovacuum: true" do
+      @client.create_unlogged(@queue_name, tune_autovacuum: true)
+
+      assert_in_delta 0.01, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+    end
+
+    it "still returns the created/existed boolean when tuning" do
+      assert @client.create(@queue_name, tune_autovacuum: true)
+      refute @client.create(@queue_name, tune_autovacuum: true)
+    end
+  end
+end

--- a/test/lib/pgmq/client/autovacuum_test.rb
+++ b/test/lib/pgmq/client/autovacuum_test.rb
@@ -107,6 +107,23 @@ describe PGMQ::Client::Autovacuum do
         @client.tune_autovacuum(@queue_name, scale_factor: "0.01); DROP TABLE pgmq.meta; --")
       end
     end
+
+    it "tunes the correct table for a mixed-case queue name" do
+      # PGMQ folds queue names to lower case for the backing tables, so tune_autovacuum must target the lower-cased
+      # table (pgmq.q_<name>) rather than the mixed-case name verbatim.
+      mixed = "Av_Mixed_#{SecureRandom.hex(4)}"
+      @client.create(mixed)
+
+      begin
+        @client.tune_autovacuum(mixed)
+
+        opts = reloptions("q_#{mixed.downcase}")
+
+        assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
+      ensure
+        @client.drop_queue(mixed)
+      end
+    end
   end
 
   describe "create with tune_autovacuum option" do


### PR DESCRIPTION
## Motivation

PGMQ tables churn in a way PostgreSQL's defaults are not tuned for: a hot queue inserts, updates (visibility timeout), and deletes rows constantly, so dead tuples accumulate fast. With the default `autovacuum_vacuum_scale_factor` of `0.2`, autovacuum only runs once dead tuples reach 20% of the table — by which point a busy queue has bloated its heap and indexes, slowing every read. The archive table grows mostly by append and benefits from a gentler-but-tightened setting.

Operators currently have to hand-write `ALTER TABLE pgmq.q_<name> SET (...)` after every `create`. This adds a first-class, **opt-in** helper.

## What changed

- **`Client#tune_autovacuum(queue_name, scale_factor:, threshold:, archive:, archive_scale_factor:, archive_threshold:)`** — sets per-table autovacuum storage params via `ALTER TABLE` on `pgmq.q_<name>` and (unless `archive: false`) `pgmq.a_<name>`. Defaults: queue `0.01/50`, archive `0.05/50`. All overridable.
- **`tune_autovacuum:` keyword on `create` / `create_unlogged` / `create_partitioned`** — `false` (default, no change), `true` (tuned defaults), or a Hash of the options above. Applied on the same connection that created the queue.

Opt-in by design: the thin wrapper never mutates storage parameters unless asked.

## Safety

- Identifiers can't be bind params, so the table name is quoted with `conn.quote_ident`; the queue name has already passed `validate_queue_name!` (strict identifier rules).
- Numeric values are coerced with `Float()` / `Integer()` before interpolation — a non-numeric `scale_factor` raises `ArgumentError` rather than reaching the SQL (covered by a test).
- The queue name is **lower-cased** before quoting, because PGMQ folds queue names to lower case for the backing tables (`create('MyQueue')` → `q_myqueue`). Without this, mixed-case queues would target a non-existent relation.

## Notes

On a partitioned queue/archive, params are set on the partitioned parent; PostgreSQL does not cascade storage params to existing partitions (documented).

## Tests

17 tests covering defaults, per-table overrides, `archive: false`, idempotency, invalid/nonexistent queues, the SQL-injection guard, a mixed-case-queue regression, and the `create*` flag forms. Full suite green, lint clean.
