### PR TITLE
feat(queue-name): add normalize/sanitize tiers via PGMQ::QueueName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 0.7.0 (Unreleased)
 
+### Queue Naming
+- **[Feature]** Add `PGMQ::QueueName`, a module that is now the single source of truth for queue-name rules and
+  exposes a three-tier API for deriving valid names from less-trusted input:
+  - `PGMQ::QueueName.valid?(name)` / `PGMQ::QueueName.validate!(name)` - the existing strict check (used internally
+    by every `PGMQ::Client` operation); `validate!` returns the name when valid and raises
+    `PGMQ::Errors::InvalidQueueNameError` otherwise.
+  - `PGMQ::QueueName.normalize(name)` - rewrites a name meant to be valid but using friendly separators
+    (hyphens, colons, dots, spaces become underscores), e.g. a Turbo Stream channel `"chat:room-7"` →
+    `"chat_room_7"`. Raises if the result still can't be valid (empty, or starts with a digit).
+  - `PGMQ::QueueName.sanitize(name)` - coerces arbitrary, untrusted input into a valid name on a best-effort basis;
+    never raises for content (lowercases, replaces illegal runs, prefixes leading digits, truncates to the length
+    limit, falls back to `"queue"` when nothing usable remains).
+
+  `PGMQ::Client#validate_queue_name!` now delegates to `PGMQ::QueueName.validate!`; error messages are unchanged.
+
 ### Queue Maintenance
 - **[Feature]** Add `list_notify_insert_throttles` — returns an array of `PGMQ::NotifyThrottle`
   objects (one per queue with NOTIFY enabled), each carrying `queue_name`, `throttle_interval_ms`,

--- a/README.md
+++ b/README.md
@@ -403,6 +403,34 @@ client.create("a" * 48)          # ✗ Too long (48+ chars)
 # Raises PGMQ::Errors::InvalidQueueNameError
 ```
 
+**Deriving valid names with `PGMQ::QueueName`**
+
+`PGMQ::Client` always validates the name you pass (via `PGMQ::QueueName.validate!`).
+When the name comes from a friendlier source — a Turbo Stream channel, a slug, or
+untrusted user input — `PGMQ::QueueName` gives you three tiers so you can decide
+how strict to be:
+
+```ruby
+# Tier 1 — assert a name you control is valid (raises otherwise)
+PGMQ::QueueName.valid?("orders")          # => true
+PGMQ::QueueName.validate!("my-queue")     # => raises PGMQ::Errors::InvalidQueueNameError
+
+# Tier 2 — normalize a name meant to be valid but using friendly separators.
+# Hyphens/colons/dots/spaces become underscores; raises if the result still
+# can't be valid (empty, or starts with a digit).
+PGMQ::QueueName.normalize("chat:room-7")  # => "chat_room_7"
+PGMQ::QueueName.normalize("order events") # => "order_events"
+PGMQ::QueueName.normalize("123-go")       # => raises (starts with a digit)
+
+# Tier 3 — sanitize arbitrary, untrusted input. Never raises; always returns a
+# valid name (prefixes leading digits, truncates to length, falls back to "queue").
+PGMQ::QueueName.sanitize("99 Problems!")        # => "q_99_problems"
+PGMQ::QueueName.sanitize("Order-Events:Created") # => "order_events_created"
+PGMQ::QueueName.sanitize("!!!")                  # => "queue"
+
+client.create(PGMQ::QueueName.sanitize(params[:topic]))  # safe for user input
+```
+
 ### Sending Messages
 
 ```ruby

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -103,35 +103,17 @@ module PGMQ
     end
 
     # Validates a queue name
+    #
+    # Delegates to {PGMQ::QueueName.validate!}, the single source of truth for queue-name rules. See
+    # {PGMQ::QueueName} for the +normalize+ and +sanitize+ helpers if you need to derive a valid name from
+    # friendlier or untrusted input before calling a queue operation.
+    #
     # @param queue_name [String] queue name to validate
     # @return [void]
     # @raise [PGMQ::Errors::InvalidQueueNameError] if name is invalid
     def validate_queue_name!(queue_name)
-      if queue_name.nil? || queue_name.to_s.strip.empty?
-        raise(
-          Errors::InvalidQueueNameError,
-          "Queue name cannot be empty"
-        )
-      end
-
-      # PGMQ creates tables with prefixes (pgmq.q_<name>, pgmq.a_<name>). PostgreSQL has a 63-character limit for
-      # identifiers, but PGMQ enforces 48 to account for prefixes and potential suffixes.
-      if queue_name.to_s.length >= 48
-        raise(
-          Errors::InvalidQueueNameError,
-          "Queue name '#{queue_name}' exceeds maximum length of 48 characters " \
-          "(current length: #{queue_name.to_s.length})"
-        )
-      end
-
-      # PostgreSQL identifier rules: start with letter or underscore, contain only letters, digits, underscores
-      return if queue_name.to_s.match?(/\A[a-zA-Z_][a-zA-Z0-9_]*\z/)
-
-      raise(
-        Errors::InvalidQueueNameError,
-        "Invalid queue name '#{queue_name}': must start with a letter or underscore " \
-        "and contain only letters, digits, and underscores"
-      )
+      QueueName.validate!(queue_name)
+      nil
     end
   end
 end

--- a/lib/pgmq/queue_name.rb
+++ b/lib/pgmq/queue_name.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module PGMQ
+  # Queue name validation, normalization, and sanitization.
+  #
+  # PGMQ interpolates a queue's name into PostgreSQL identifiers (it creates tables named +pgmq.q_<name>+ and
+  # +pgmq.a_<name>+), so a name has to be a valid, length-bounded SQL identifier. This module is the single source of
+  # truth for those rules and offers three tiers depending on how much you trust the input:
+  #
+  # 1. {.validate!} / {.valid?} - assert a name is already valid. Use for names you control. {PGMQ::Client} calls
+  #    {.validate!} before every operation.
+  # 2. {.normalize} - lightly rewrite a name that is *meant* to be valid but uses a friendlier separator (hyphens,
+  #    colons, dots, spaces), e.g. a Turbo Stream channel like +"chat:room-7"+. Raises if the result still can't be a
+  #    valid name (empty, or starts with a digit).
+  # 3. {.sanitize} - coerce *arbitrary, untrusted* input into a valid name on a best-effort basis. Never raises for
+  #    content; always returns a usable identifier (falling back to a default when nothing usable remains).
+  #
+  # @example
+  #   PGMQ::QueueName.valid?("orders")          # => true
+  #   PGMQ::QueueName.validate!("my-queue")     # => raises InvalidQueueNameError
+  #   PGMQ::QueueName.normalize("chat:room-7")  # => "chat_room_7"
+  #   PGMQ::QueueName.sanitize("99 Problems!")  # => "q_99_problems"
+  module QueueName
+    # Maximum queue name length. PGMQ creates tables with prefixes (+q_+, +a_+) and PostgreSQL caps identifiers at 63
+    # characters; PGMQ enforces 48 to leave room for those prefixes and suffixes.
+    MAX_LENGTH = 48
+
+    # A valid queue name: starts with a letter or underscore, then letters, digits, or underscores.
+    PATTERN = /\A[a-zA-Z_][a-zA-Z0-9_]*\z/
+
+    # Prefix used by {.sanitize} when the input would otherwise start with an illegal leading character (e.g. a
+    # digit) but still has usable trailing characters.
+    SANITIZE_PREFIX = "q_"
+
+    # Name {.sanitize} falls back to when the input has no usable characters at all.
+    SANITIZE_FALLBACK = "queue"
+
+    module_function
+
+    # Returns true if the name is already a valid queue name.
+    #
+    # @param name [String, #to_s] candidate queue name
+    # @return [Boolean]
+    def valid?(name)
+      str = name.to_s
+      !str.empty? && str.length < MAX_LENGTH && str.match?(PATTERN)
+    end
+
+    # Validates a queue name, returning it unchanged when valid and raising otherwise.
+    #
+    # @param name [String, #to_s] candidate queue name
+    # @return [String] the validated name (as a String)
+    # @raise [PGMQ::Errors::InvalidQueueNameError] if the name is empty, too long, or not a valid identifier
+    def validate!(name)
+      str = name.to_s
+
+      if name.nil? || str.strip.empty?
+        raise Errors::InvalidQueueNameError, "Queue name cannot be empty"
+      end
+
+      if str.length >= MAX_LENGTH
+        raise Errors::InvalidQueueNameError,
+          "Queue name '#{str}' exceeds maximum length of #{MAX_LENGTH} characters " \
+          "(current length: #{str.length})"
+      end
+
+      return str if str.match?(PATTERN)
+
+      raise Errors::InvalidQueueNameError,
+        "Invalid queue name '#{str}': must start with a letter or underscore " \
+        "and contain only letters, digits, and underscores"
+    end
+
+    # Rewrites a name that is meant to be valid but uses friendlier separators.
+    #
+    # Trims surrounding whitespace, replaces any run of non-identifier characters with a single underscore, and
+    # collapses repeated underscores. This turns names like +"chat:room-7"+ or +"order events"+ into +"chat_room_7"+
+    # / +"order_events"+. The result is then validated, so names that still can't be valid (empty, or starting with a
+    # digit) raise rather than being silently mangled.
+    #
+    # @param name [String, #to_s] a name using friendly separators
+    # @return [String] the normalized, validated queue name
+    # @raise [PGMQ::Errors::InvalidQueueNameError] if the normalized result is not a valid queue name
+    def normalize(name)
+      normalized = name.to_s.strip
+        .gsub(/[^a-zA-Z0-9_]+/, "_").squeeze("_")
+        .gsub(/\A_+|_+\z/, "")
+
+      validate!(normalized)
+    end
+
+    # Coerces arbitrary, untrusted input into a valid queue name on a best-effort basis.
+    #
+    # Unlike {.normalize}, this never raises for content: it lowercases, replaces every illegal character run with an
+    # underscore, strips leading/trailing underscores, prefixes {SANITIZE_PREFIX} when the first surviving character
+    # is not a valid identifier start (e.g. a digit), truncates to fit {MAX_LENGTH}, and falls back to
+    # {SANITIZE_FALLBACK} when nothing usable remains. The return value always satisfies {.valid?}.
+    #
+    # Use for names derived from user input or external systems where you would rather get a deterministic, safe
+    # queue name than an exception.
+    #
+    # @param name [String, #to_s] untrusted input
+    # @return [String] a guaranteed-valid queue name
+    def sanitize(name)
+      cleaned = name.to_s.downcase
+        .gsub(/[^a-z0-9_]+/, "_").squeeze("_")
+        .gsub(/\A_+|_+\z/, "")
+
+      # Nothing usable survived the scrub - use the fallback rather than emit a bare prefix like "q_".
+      return SANITIZE_FALLBACK if cleaned.empty?
+
+      # A valid identifier can't start with a digit; prefix so the leading character is legal.
+      cleaned = "#{SANITIZE_PREFIX}#{cleaned}" unless cleaned.match?(/\A[a-z_]/)
+
+      # Keep under MAX_LENGTH (valid? requires strictly less than), trimming any underscore left at the cut.
+      cleaned = cleaned[0, MAX_LENGTH - 1].sub(/_+\z/, "") if cleaned.length >= MAX_LENGTH
+
+      cleaned.empty? ? SANITIZE_FALLBACK : cleaned
+    end
+  end
+end

--- a/test/lib/pgmq/queue_name_test.rb
+++ b/test/lib/pgmq/queue_name_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+describe PGMQ::QueueName do
+  describe ".valid?" do
+    it "returns true for valid identifiers" do
+      assert PGMQ::QueueName.valid?("orders")
+      assert PGMQ::QueueName.valid?("My_Queue_1")
+      assert PGMQ::QueueName.valid?("_private")
+      assert PGMQ::QueueName.valid?("a" * 47)
+    end
+
+    it "returns false for invalid identifiers" do
+      refute PGMQ::QueueName.valid?("my-queue")
+      refute PGMQ::QueueName.valid?("123queue")
+      refute PGMQ::QueueName.valid?("my.queue")
+      refute PGMQ::QueueName.valid?("")
+      refute PGMQ::QueueName.valid?("a" * 48)
+      refute PGMQ::QueueName.valid?(nil)
+    end
+  end
+
+  describe ".validate!" do
+    it "returns the name unchanged when valid" do
+      assert_equal "orders", PGMQ::QueueName.validate!("orders")
+    end
+
+    it "coerces non-string input to a String" do
+      assert_equal "orders", PGMQ::QueueName.validate!(:orders)
+    end
+
+    it "raises for empty names" do
+      e = assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.validate!("") }
+      assert_match(/cannot be empty/, e.message)
+    end
+
+    it "raises for nil" do
+      e = assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.validate!(nil) }
+      assert_match(/cannot be empty/, e.message)
+    end
+
+    it "raises for whitespace-only names" do
+      e = assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.validate!("   ") }
+      assert_match(/cannot be empty/, e.message)
+    end
+
+    it "raises with length detail for names that are too long" do
+      e = assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.validate!("a" * 48) }
+      assert_match(/exceeds maximum length of 48 characters.*current length: 48/, e.message)
+    end
+
+    it "raises with identifier detail for illegal characters" do
+      e = assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.validate!("my-queue") }
+      assert_match(/must start with a letter or underscore/, e.message)
+    end
+  end
+
+  describe ".normalize" do
+    it "replaces friendly separators with underscores" do
+      assert_equal "chat_room_7", PGMQ::QueueName.normalize("chat:room-7")
+      assert_equal "order_events", PGMQ::QueueName.normalize("order events")
+      assert_equal "Foo_Bar", PGMQ::QueueName.normalize("Foo.Bar")
+    end
+
+    it "collapses repeated separators into a single underscore" do
+      assert_equal "a_b_c", PGMQ::QueueName.normalize("a--b__c")
+    end
+
+    it "trims leading and trailing separators and whitespace" do
+      assert_equal "spaced", PGMQ::QueueName.normalize("  spaced  ")
+      assert_equal "edge", PGMQ::QueueName.normalize("--edge--")
+    end
+
+    it "leaves an already-valid name unchanged" do
+      assert_equal "orders", PGMQ::QueueName.normalize("orders")
+    end
+
+    it "raises when the normalized result starts with a digit" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.normalize("123-go") }
+    end
+
+    it "raises when nothing valid remains" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.normalize("!!!") }
+    end
+
+    it "raises when the normalized result exceeds the length limit" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.normalize("a-" * 30) }
+    end
+  end
+
+  describe ".sanitize" do
+    it "always returns a valid queue name" do
+      [
+        "99 Problems!",
+        "Order-Events:Created",
+        "MixedCASE",
+        "x" * 80,
+        "café au lait"
+      ].each do |input|
+        result = PGMQ::QueueName.sanitize(input)
+
+        assert PGMQ::QueueName.valid?(result), "expected sanitize(#{input.inspect}) => #{result.inspect} to be valid"
+      end
+    end
+
+    it "lowercases and underscores separators" do
+      assert_equal "order_events_created", PGMQ::QueueName.sanitize("Order-Events:Created")
+    end
+
+    it "prefixes names that would start with a digit" do
+      assert_equal "q_99_problems", PGMQ::QueueName.sanitize("99 Problems!")
+      assert_equal "q_123", PGMQ::QueueName.sanitize("123")
+    end
+
+    it "falls back to a default when nothing usable remains" do
+      assert_equal "queue", PGMQ::QueueName.sanitize("")
+      assert_equal "queue", PGMQ::QueueName.sanitize("!!!")
+      assert_equal "queue", PGMQ::QueueName.sanitize("___")
+    end
+
+    it "truncates to fit the length limit" do
+      result = PGMQ::QueueName.sanitize("a" * 80)
+
+      assert_operator result.length, :<, PGMQ::QueueName::MAX_LENGTH
+      assert PGMQ::QueueName.valid?(result)
+    end
+
+    it "does not raise for arbitrary input" do
+      assert_equal "queue", PGMQ::QueueName.sanitize(nil)
+      PGMQ::QueueName.sanitize(12_345)
+      PGMQ::QueueName.sanitize(:some_symbol)
+    end
+
+    it "produces a name a client can actually create" do
+      client = create_test_client
+      name = PGMQ::QueueName.sanitize("Tenant 42: Orders/Inbound!")
+
+      begin
+        assert client.create(name)
+        assert_includes client.list_queues.map(&:queue_name), name
+      ensure
+        client.drop_queue(name)
+        client.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

PGMQ interpolates a queue's name into PostgreSQL identifiers (`pgmq.q_<name>` / `pgmq.a_<name>`), so a name must be a valid, length-bounded identifier. Today the only tool is the strict, internal `validate_queue_name!`, which **raises** on anything that isn't already valid.

Callers that derive a queue name from a friendlier source — a Turbo Stream channel like `"chat:room-7"`, a slug, or untrusted user input — have to roll their own transformation. This adds a small, documented public API for that, with three tiers matched to how much the input is trusted.

## What changed

New module **`PGMQ::QueueName`**, the single source of truth for queue-name rules:

- **`valid?(name)` / `validate!(name)`** — the existing strict check, now centralised. `validate!` returns the name when valid and raises `InvalidQueueNameError` otherwise. (`Client#validate_queue_name!` now delegates here; error messages are unchanged.)
- **`normalize(name)`** — rewrites a name meant to be valid but using friendly separators (hyphens/colons/dots/spaces → underscores), e.g. `"chat:room-7"` → `"chat_room_7"`. Raises if the result still can't be valid (empty, or starts with a digit).
- **`sanitize(name)`** — coerces arbitrary, untrusted input into a valid name on a best-effort basis; **never raises** for content (lowercases, replaces illegal runs, prefixes leading digits, truncates to the length limit, falls back to `"queue"`). The return value always satisfies `valid?`.

```ruby
PGMQ::QueueName.normalize("chat:room-7")   # => "chat_room_7"
PGMQ::QueueName.sanitize("99 Problems!")   # => "q_99_problems"
client.create(PGMQ::QueueName.sanitize(params[:topic]))  # safe for user input
```

## Behavior preservation

`Client#validate_queue_name!` delegates to `QueueName.validate!`, which carries the identical empty/length/identifier error messages — existing client tests pass unchanged.

## Tests

23 unit tests covering `valid?`/`validate!`/`normalize`/`sanitize` edge cases (leading digits, all-illegal input, length boundaries, non-ASCII, idempotency) plus a real-DB round-trip that `create`s a sanitized name. Full suite green, lint clean.
