### PR TITLE
feat(autovacuum): tune cost_delay, analyze_scale_factor, and fillfactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,16 +50,20 @@
   `read_grouped_head`). The operation is idempotent.
 - **[Feature]** Add `create_fifo_indexes_all` - convenience wrapper that creates FIFO indexes on every queue
   registered in `pgmq.meta`. Useful for one-time migrations when adding grouped reads to an existing deployment.
-- **[Feature]** Add `tune_autovacuum(queue_name, ...)` - sets per-table autovacuum storage parameters on a queue's
-  tables (`pgmq.q_<name>` and, unless `archive: false`, `pgmq.a_<name>`) via `ALTER TABLE`. PGMQ tables churn under
-  constant insert/update/delete, so PostgreSQL's default `autovacuum_vacuum_scale_factor` of 0.2 lets dead tuples
-  and index bloat accumulate before autovacuum runs. Defaults tighten the queue table to `scale_factor 0.01,
-  threshold 50` and the archive to `scale_factor 0.05, threshold 50`; all four are overridable. The numeric values
-  are coerced (`Float`/`Integer`) and the table name is quoted (`quote_ident`) before the `ALTER TABLE`. Opt-in:
-  the gem does not change storage parameters unless asked.
+- **[Feature]** Add `tune_autovacuum(queue_name, queue_settings:, archive:, archive_settings:)` - sets per-table
+  autovacuum and storage parameters on a queue's tables (`pgmq.q_<name>` and, unless `archive: false`,
+  `pgmq.a_<name>`) via `ALTER TABLE`. PGMQ tables churn under constant insert/update/delete (every read UPDATEs
+  `vt`/`read_ct`/`last_read_at`), so PostgreSQL's defaults (`autovacuum_vacuum_scale_factor` 0.2, `fillfactor` 100)
+  let dead tuples and index/page bloat accumulate before autovacuum runs. The tuned defaults set, on the queue
+  table: `autovacuum_vacuum_scale_factor 0.01`, `autovacuum_vacuum_threshold 50`, `autovacuum_vacuum_cost_delay 2`,
+  `autovacuum_analyze_scale_factor 0.05`, and `fillfactor 70` (the indexed per-read UPDATE is not HOT-eligible, so
+  page headroom helps); and on the archive table the same minus `fillfactor` (append-only) with `cost_delay 5`.
+  Pass `queue_settings:`/`archive_settings:` Hashes to override individual parameters (merged onto the defaults).
+  Parameter names are allow-listed and values coerced (`Float`/`Integer`); the table name is quoted (`quote_ident`)
+  and lower-cased to match PGMQ's table naming. Opt-in: the gem does not change storage parameters unless asked.
 - **[Feature]** `create`, `create_unlogged`, and `create_partitioned` accept a `tune_autovacuum:` keyword. Pass
-  `true` to apply the tuned defaults to the new queue's tables, or a Hash of the `tune_autovacuum` options. Defaults
-  to `false` (no change), preserving the thin-wrapper behaviour.
+  `true` to apply the tuned defaults to the new queue's tables, or a Hash of the `tune_autovacuum` keyword options.
+  Defaults to `false` (no change), preserving the thin-wrapper behaviour.
 
 ### Message Operations
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers

--- a/README.md
+++ b/README.md
@@ -472,40 +472,56 @@ client.create(PGMQ::QueueName.sanitize(params[:topic]))  # safe for user input
 
 #### Autovacuum Tuning
 
-PGMQ tables churn in a way PostgreSQL's defaults are not tuned for: a hot queue
-inserts, updates (visibility timeout), and deletes rows constantly, so dead
-tuples pile up fast. With the default `autovacuum_vacuum_scale_factor` of `0.2`,
-autovacuum only runs once dead tuples reach 20% of the table — by which point a
-busy queue has bloated its heap and indexes, slowing every read. The archive
-table grows mostly by append, so it benefits from a gentler-but-still-tightened
-setting.
+PGMQ tables churn in a way PostgreSQL's defaults are not tuned for. A hot queue
+inserts, updates, and deletes rows constantly: every read UPDATEs `vt`,
+`read_ct`, and `last_read_at`, and every read+archive cycle deletes from the
+queue table and inserts into the archive. Two defaults hurt:
+
+- `autovacuum_vacuum_scale_factor` defaults to `0.2`, so autovacuum only runs
+  once dead tuples reach 20% of the table — by which point a busy queue has
+  bloated its heap and B-tree indexes, slowing every read and lock.
+- `fillfactor` defaults to `100`, so heap pages fill completely. Because `vt` is
+  indexed and changes on every read, those UPDATEs are not HOT-eligible; leaving
+  page headroom reduces page density between vacuum passes.
 
 `tune_autovacuum` sets per-table storage parameters via `ALTER TABLE`, so
-autovacuum runs far more often on *these specific tables* without touching
-cluster-wide settings. It is **opt-in** — the gem never mutates storage
-parameters unless you ask.
+autovacuum runs far more often (and fillfactor reserves churn headroom) on
+*these specific tables* without touching cluster-wide settings. It is **opt-in**
+— the gem never mutates storage parameters unless you ask.
+
+The tuned defaults:
+
+| Parameter | Queue table (`pgmq.q_…`) | Archive table (`pgmq.a_…`) |
+|-----------|--------------------------|----------------------------|
+| `autovacuum_vacuum_scale_factor`  | `0.01` | `0.05` |
+| `autovacuum_vacuum_threshold`     | `50`   | `50`   |
+| `autovacuum_vacuum_cost_delay`    | `2`    | `5`    |
+| `autovacuum_analyze_scale_factor` | `0.05` | `0.05` |
+| `fillfactor`                      | `70`   | — (append-only, not set) |
 
 ```ruby
-# Tune an existing queue with PGMQ defaults:
-#   queue table   (pgmq.q_<name>): scale_factor 0.01, threshold 50
-#   archive table (pgmq.a_<name>): scale_factor 0.05, threshold 50
+# Tune an existing queue with the PGMQ-tuned defaults above
 client.tune_autovacuum("orders")
 
-# Override the queue setting and skip the archive table
-client.tune_autovacuum("orders", scale_factor: 0.005, archive: false)
-
-# Override every parameter
+# Override individual parameters (merged onto the defaults) and skip the archive
 client.tune_autovacuum("orders",
-  scale_factor: 0.01, threshold: 50,
-  archive_scale_factor: 0.05, archive_threshold: 50)
+  queue_settings: { autovacuum_vacuum_scale_factor: 0.005, fillfactor: 80 },
+  archive: false)
 
-# Or tune at creation time (true = defaults, or pass a Hash of the options above)
+# Override an archive parameter only
+client.tune_autovacuum("orders", archive_settings: { autovacuum_vacuum_scale_factor: 0.02 })
+
+# Or tune at creation time (true = defaults, or a Hash of the keywords above)
 client.create("orders", tune_autovacuum: true)
-client.create("orders", tune_autovacuum: { scale_factor: 0.005, archive: false })
+client.create("orders", tune_autovacuum: { queue_settings: { fillfactor: 80 }, archive: false })
 client.create_unlogged("fast", tune_autovacuum: true)
 client.create_partitioned("big", partition_interval: "daily",
   retention_interval: "7 days", tune_autovacuum: true)
 ```
+
+Only parameters you name in `queue_settings:` / `archive_settings:` change; the
+rest keep the tuned defaults. Values are coerced (`Float`/`Integer`) and
+parameter names are allow-listed before they reach the `ALTER TABLE`.
 
 > **Partitioned queues:** parameters are set on the partitioned *parent* table.
 > PostgreSQL does not cascade storage parameters to existing partitions, so set

--- a/lib/pgmq/client/autovacuum.rb
+++ b/lib/pgmq/client/autovacuum.rb
@@ -2,49 +2,67 @@
 
 module PGMQ
   class Client
-    # Autovacuum tuning for queue and archive tables.
+    # Autovacuum and storage tuning for queue and archive tables.
     #
-    # PGMQ tables churn in a way PostgreSQL's defaults are not tuned for: a hot queue inserts, updates (visibility
-    # timeout), and deletes rows constantly, so dead tuples accumulate fast. With the default
-    # +autovacuum_vacuum_scale_factor+ of 0.2, autovacuum only kicks in after dead tuples reach 20% of the table -
-    # by which point a busy queue has bloated its heap and indexes, slowing every read. The archive table grows
-    # monotonically (append + occasional prune), so it benefits from a gentler but still-tightened setting.
+    # PGMQ tables churn in a way PostgreSQL's defaults are not tuned for. A hot queue inserts, updates, and deletes
+    # rows constantly: every read UPDATEs +vt+, +read_ct+, and +last_read_at+, and every read+archive cycle deletes
+    # from the queue table and inserts into the archive. Two defaults hurt under that load:
     #
-    # This module applies per-table storage parameters via +ALTER TABLE+ so autovacuum runs far more often on these
-    # specific tables without touching cluster-wide settings. It is intentionally opt-in: the gem is a thin wrapper
-    # and does not mutate table storage parameters unless you ask it to (either by calling {#tune_autovacuum} or by
-    # passing +tune_autovacuum: true+ to a queue-creation method).
+    # - +autovacuum_vacuum_scale_factor+ defaults to 0.2, so autovacuum only runs after dead tuples reach 20% of the
+    #   table - by which point a busy queue has bloated its heap and B-tree indexes, slowing every read and lock.
+    # - +fillfactor+ defaults to 100, so heap pages fill completely. Because +vt+ is indexed and changes on every
+    #   read, those UPDATEs are not HOT-eligible; leaving page headroom reduces page density between vacuum passes.
+    #
+    # This module applies per-table storage parameters via +ALTER TABLE+ so autovacuum runs far more often (and
+    # fillfactor reserves churn headroom) on these specific tables, without touching cluster-wide settings. It is
+    # intentionally opt-in: the gem is a thin wrapper and does not mutate table storage parameters unless you ask it
+    # to (either by calling {#tune_autovacuum} or by passing +tune_autovacuum: true+ to a queue-creation method).
     #
     # @see https://www.postgresql.org/docs/current/runtime-config-autovacuum.html
+    # @see https://planetscale.com/blog/keeping-a-postgres-queue-healthy
     module Autovacuum
-      # Aggressive scale factor for the active queue table. Triggers autovacuum once dead tuples reach 1% of the
-      # table (plus the threshold), keeping a hot queue's heap and indexes from bloating under read+delete churn.
-      DEFAULT_QUEUE_SCALE_FACTOR = 0.01
+      # Default storage parameters for the active queue table. Aggressive: autovacuum and autoanalyze trigger at 1%/5%
+      # dead-or-changed tuples, a small +cost_delay+ keeps each vacuum pass quick, and +fillfactor+ reserves 30% of
+      # each page for the per-read UPDATE churn (the queue table is the only one that benefits from fillfactor).
+      DEFAULT_QUEUE_SETTINGS = {
+        autovacuum_vacuum_scale_factor: 0.01,
+        autovacuum_vacuum_threshold: 50,
+        autovacuum_vacuum_cost_delay: 2,
+        autovacuum_analyze_scale_factor: 0.05,
+        fillfactor: 70
+      }.freeze
 
-      # Flat dead-tuple floor for the queue table, added to the scale-factor term. Keeps small queues from waiting on
-      # the percentage alone.
-      DEFAULT_QUEUE_THRESHOLD = 50
+      # Default storage parameters for the archive table. Archives are append-heavy with periodic purge, so a looser
+      # scale factor and a slightly higher cost delay are enough while still beating the 0.2 default. No fillfactor:
+      # archive rows are inserted once and never updated, so there is no page-churn headroom to reserve.
+      DEFAULT_ARCHIVE_SETTINGS = {
+        autovacuum_vacuum_scale_factor: 0.05,
+        autovacuum_vacuum_threshold: 50,
+        autovacuum_vacuum_cost_delay: 5,
+        autovacuum_analyze_scale_factor: 0.05
+      }.freeze
 
-      # Scale factor for the archive table. Archives grow mostly by append, so a looser factor than the queue is
-      # enough while still beating the 0.2 default.
-      DEFAULT_ARCHIVE_SCALE_FACTOR = 0.05
+      # Storage parameters whose values are interpolated as Floats; everything else is interpolated as an Integer.
+      FLOAT_SETTINGS = %i[
+        autovacuum_vacuum_scale_factor
+        autovacuum_analyze_scale_factor
+      ].freeze
+      private_constant :FLOAT_SETTINGS
 
-      # Flat dead-tuple floor for the archive table.
-      DEFAULT_ARCHIVE_THRESHOLD = 50
-
-      # Tunes autovacuum storage parameters on a queue's underlying tables.
+      # Tunes autovacuum and storage parameters on a queue's underlying tables.
       #
-      # Sets +autovacuum_vacuum_scale_factor+ and +autovacuum_vacuum_threshold+ on the queue table
-      # (+pgmq.q_<name>+) and, unless +archive: false+, on the archive table (+pgmq.a_<name>+). Existing PostgreSQL
-      # defaults for any other parameter are left untouched. Safe to call repeatedly - +ALTER TABLE ... SET+ is
-      # idempotent for a given value.
+      # Applies {DEFAULT_QUEUE_SETTINGS} to the queue table (+pgmq.q_<name>+) and, unless +archive: false+,
+      # {DEFAULT_ARCHIVE_SETTINGS} to the archive table (+pgmq.a_<name>+). Pass +queue_settings:+ / +archive_settings:+
+      # to override or extend the parameters per table; the Hash you pass is merged onto the defaults, so you only
+      # name the keys you want to change. Any other PostgreSQL storage default is left untouched. Safe to call
+      # repeatedly - +ALTER TABLE ... SET+ is idempotent for a given value.
       #
       # @param queue_name [String] name of the queue
-      # @param scale_factor [Float] queue table +autovacuum_vacuum_scale_factor+
-      # @param threshold [Integer] queue table +autovacuum_vacuum_threshold+
+      # @param queue_settings [Hash{Symbol=>Numeric}] storage params for the queue table, merged onto
+      #   {DEFAULT_QUEUE_SETTINGS}
       # @param archive [Boolean] also tune the archive table (default: true)
-      # @param archive_scale_factor [Float] archive table +autovacuum_vacuum_scale_factor+
-      # @param archive_threshold [Integer] archive table +autovacuum_vacuum_threshold+
+      # @param archive_settings [Hash{Symbol=>Numeric}] storage params for the archive table, merged onto
+      #   {DEFAULT_ARCHIVE_SETTINGS}
       # @return [void]
       # @raise [PGMQ::Errors::InvalidQueueNameError] if the queue name is invalid
       # @raise [PGMQ::Errors::ConnectionError] if the database operation fails (e.g. the queue does not exist)
@@ -52,31 +70,23 @@ module PGMQ
       # @example Apply PGMQ-tuned defaults to an existing queue
       #   client.tune_autovacuum("orders")
       #
-      # @example Override the queue scale factor, skip the archive
-      #   client.tune_autovacuum("orders", scale_factor: 0.005, archive: false)
+      # @example Override a couple of queue params, skip the archive
+      #   client.tune_autovacuum("orders", queue_settings: { autovacuum_vacuum_scale_factor: 0.005, fillfactor: 80 },
+      #                          archive: false)
       #
       # @note On a partitioned queue or archive, the parameters are set on the parent table. PostgreSQL does not
       #   cascade storage parameters to existing partitions, so pre-existing partitions keep their own settings;
       #   set them per-partition if needed.
-      def tune_autovacuum(
-        queue_name,
-        scale_factor: DEFAULT_QUEUE_SCALE_FACTOR,
-        threshold: DEFAULT_QUEUE_THRESHOLD,
-        archive: true,
-        archive_scale_factor: DEFAULT_ARCHIVE_SCALE_FACTOR,
-        archive_threshold: DEFAULT_ARCHIVE_THRESHOLD
-      )
+      def tune_autovacuum(queue_name, queue_settings: {}, archive: true, archive_settings: {})
         validate_queue_name!(queue_name)
 
         with_connection do |conn|
           tune_autovacuum_on(
             conn,
             queue_name,
-            scale_factor: scale_factor,
-            threshold: threshold,
+            queue_settings: queue_settings,
             archive: archive,
-            archive_scale_factor: archive_scale_factor,
-            archive_threshold: archive_threshold
+            archive_settings: archive_settings
           )
         end
 
@@ -85,64 +95,85 @@ module PGMQ
 
       private
 
-      # Resolves autovacuum options against the PGMQ-tuned defaults and applies them on an existing connection.
+      # Resolves storage settings against the PGMQ-tuned defaults and applies them on an existing connection.
       #
       # Single source of truth for both entry points: {#tune_autovacuum} (which passes its keyword arguments through)
       # and the +tune_autovacuum:+ creation flag (which passes a possibly-empty Hash). Keeping the default resolution
-      # and the archive-skip rule here means the two paths cannot drift - in particular, +archive+ is treated as a
-      # single truthiness test in one place rather than being checked differently per caller.
+      # and the archive-skip rule here means the two paths cannot drift - +archive+ is a single truthiness test in one
+      # place, and per-table overrides are merged onto the defaults in one place.
       #
       # @param conn [PG::Connection] the connection to run the ALTER TABLE statements on
       # @param queue_name [String] name of the queue (already validated)
-      # @param opts [Hash] resolved or partial options; missing keys fall back to the DEFAULT_* constants
-      # @option opts [Float] :scale_factor queue table +autovacuum_vacuum_scale_factor+
-      # @option opts [Integer] :threshold queue table +autovacuum_vacuum_threshold+
-      # @option opts [Boolean] :archive also tune the archive table (default: true)
-      # @option opts [Float] :archive_scale_factor archive table +autovacuum_vacuum_scale_factor+
-      # @option opts [Integer] :archive_threshold archive table +autovacuum_vacuum_threshold+
+      # @param queue_settings [Hash] queue-table overrides, merged onto {DEFAULT_QUEUE_SETTINGS}
+      # @param archive [Boolean] also tune the archive table
+      # @param archive_settings [Hash] archive-table overrides, merged onto {DEFAULT_ARCHIVE_SETTINGS}
       # @return [void]
-      def tune_autovacuum_on(conn, queue_name, opts = {})
-        alter_autovacuum(
-          conn,
-          "q_#{queue_name}",
-          opts.fetch(:scale_factor, DEFAULT_QUEUE_SCALE_FACTOR),
-          opts.fetch(:threshold, DEFAULT_QUEUE_THRESHOLD)
-        )
+      def tune_autovacuum_on(conn, queue_name, queue_settings: {}, archive: true, archive_settings: {})
+        alter_storage(conn, "q_#{queue_name}", DEFAULT_QUEUE_SETTINGS.merge(symbolize(queue_settings)))
 
-        return unless opts.fetch(:archive, true)
+        return unless archive
 
-        alter_autovacuum(
-          conn,
-          "a_#{queue_name}",
-          opts.fetch(:archive_scale_factor, DEFAULT_ARCHIVE_SCALE_FACTOR),
-          opts.fetch(:archive_threshold, DEFAULT_ARCHIVE_THRESHOLD)
-        )
+        alter_storage(conn, "a_#{queue_name}", DEFAULT_ARCHIVE_SETTINGS.merge(symbolize(archive_settings)))
       end
 
-      # Issues a single ALTER TABLE setting the two autovacuum storage parameters on one pgmq table.
+      # Issues a single ALTER TABLE setting the given storage parameters on one pgmq table.
       #
       # PGMQ folds queue names to lower case when it creates the backing tables (`pgmq.create('MyQueue')` produces
       # `pgmq.q_myqueue`), so the table name is lower-cased to match the physical table before it is quoted. Without
-      # this, a mixed-case queue name would build `q_MyQueue`, and +quote_ident+ would preserve that case and target
-      # a non-existent relation.
+      # this, a mixed-case queue name would build `q_MyQueue`, and +quote_ident+ would preserve that case and target a
+      # non-existent relation.
       #
       # Identifiers cannot be passed as bind parameters, so the table name is quoted with the connection's
-      # +quote_ident+. The queue name has already passed {#validate_queue_name!} (strict identifier rules), and the
-      # numeric values are coerced to Float/Integer, so no untrusted text reaches the statement.
+      # +quote_ident+. The queue name has already passed {#validate_queue_name!} (strict identifier rules); the
+      # parameter names are validated against the known default keys; and the values are coerced to Float/Integer, so
+      # no untrusted text reaches the statement.
       #
       # @param conn [PG::Connection] database connection
       # @param table [String] unqualified table name (e.g. "q_orders")
-      # @param scale_factor [Float] autovacuum_vacuum_scale_factor
-      # @param threshold [Integer] autovacuum_vacuum_threshold
+      # @param settings [Hash{Symbol=>Numeric}] storage parameters to set
       # @return [void]
-      def alter_autovacuum(conn, table, scale_factor, threshold)
+      def alter_storage(conn, table, settings)
         qualified = "pgmq.#{conn.quote_ident(table.downcase)}"
+        clause = settings.map { |key, value| "#{storage_param_name(key)} = #{coerce_setting(key, value)}" }.join(", ")
 
-        conn.exec(
-          "ALTER TABLE #{qualified} SET (" \
-          "autovacuum_vacuum_scale_factor = #{Float(scale_factor)}, " \
-          "autovacuum_vacuum_threshold = #{Integer(threshold)})"
-        )
+        conn.exec("ALTER TABLE #{qualified} SET (#{clause})")
+      end
+
+      # Validates a storage-parameter name against the known keys before it is interpolated into SQL.
+      #
+      # Parameter names cannot be bound; allow-listing them against the union of the queue and archive default keys
+      # keeps an arbitrary Symbol from being injected as a raw identifier.
+      #
+      # @param key [Symbol] storage parameter name
+      # @return [String] the validated parameter name
+      # @raise [ArgumentError] if the key is not a recognised storage parameter
+      def storage_param_name(key)
+        return key.to_s if known_storage_params.include?(key)
+
+        raise ArgumentError, "Unknown storage parameter #{key.inspect}; allowed: #{known_storage_params.to_a.sort}"
+      end
+
+      # @return [Set<Symbol>] the union of queue and archive default keys
+      def known_storage_params
+        @known_storage_params ||= (DEFAULT_QUEUE_SETTINGS.keys + DEFAULT_ARCHIVE_SETTINGS.keys).to_set
+      end
+
+      # Coerces a setting value to its SQL form: Float for scale factors, Integer for everything else. Raising on
+      # non-numeric input is the injection guard for values.
+      #
+      # @param key [Symbol] storage parameter name
+      # @param value [Numeric, String] the value to coerce
+      # @return [Float, Integer]
+      def coerce_setting(key, value)
+        FLOAT_SETTINGS.include?(key) ? Float(value) : Integer(value)
+      end
+
+      # Symbolizes top-level keys of a settings Hash so callers may pass either Symbol or String keys.
+      #
+      # @param settings [Hash]
+      # @return [Hash{Symbol=>Object}]
+      def symbolize(settings)
+        settings.to_h.transform_keys(&:to_sym)
       end
     end
   end

--- a/lib/pgmq/client/queue_management.rb
+++ b/lib/pgmq/client/queue_management.rb
@@ -186,24 +186,24 @@ module PGMQ
       # Applies the +tune_autovacuum:+ creation option on the create connection.
       #
       # Accepts the same shapes the create methods document: +false+/+nil+ (no-op), +true+ (PGMQ-tuned defaults), or a
-      # Hash of overrides. Delegates resolution and the ALTER TABLE statements to {Autovacuum#tune_autovacuum_on}, the
-      # single source of truth shared with {Autovacuum#tune_autovacuum}, so defaults and the archive-skip rule cannot
-      # drift between the two paths. Runs on the connection that just created the queue, so the ALTER TABLE shares that
-      # checkout rather than acquiring a second one.
+      # Hash of {Autovacuum#tune_autovacuum} keyword options (+queue_settings:+, +archive:+, +archive_settings:+).
+      # Delegates resolution and the ALTER TABLE statements to {Autovacuum#tune_autovacuum_on}, the single source of
+      # truth shared with {Autovacuum#tune_autovacuum}, so defaults and the archive-skip rule cannot drift between the
+      # two paths. Runs on the connection that just created the queue, so the ALTER TABLE shares that checkout rather
+      # than acquiring a second one.
       #
       # @param conn [PG::Connection] the connection the queue was created on
       # @param queue_name [String] name of the queue
       # @param option [Boolean, Hash] the tune_autovacuum option as passed to the create method
-      # @option option [Float] :scale_factor queue table +autovacuum_vacuum_scale_factor+
-      # @option option [Integer] :threshold queue table +autovacuum_vacuum_threshold+
+      # @option option [Hash] :queue_settings queue-table storage params, merged onto the defaults
       # @option option [Boolean] :archive also tune the archive table (default: true)
-      # @option option [Float] :archive_scale_factor archive table +autovacuum_vacuum_scale_factor+
-      # @option option [Integer] :archive_threshold archive table +autovacuum_vacuum_threshold+
+      # @option option [Hash] :archive_settings archive-table storage params, merged onto the defaults
       # @return [void]
       def apply_tune_autovacuum_option(conn, queue_name, option)
         return unless option
 
-        tune_autovacuum_on(conn, queue_name, option.is_a?(Hash) ? option : {})
+        opts = option.is_a?(Hash) ? option.transform_keys(&:to_sym) : {}
+        tune_autovacuum_on(conn, queue_name, **opts)
       end
     end
   end

--- a/test/lib/pgmq/client/autovacuum_test.rb
+++ b/test/lib/pgmq/client/autovacuum_test.rb
@@ -26,40 +26,56 @@ describe PGMQ::Client::Autovacuum do
   describe "#tune_autovacuum" do
     before { @client.create(@queue_name) }
 
-    it "applies PGMQ-tuned defaults to the queue table" do
+    it "applies all PGMQ-tuned defaults to the queue table" do
       @client.tune_autovacuum(@queue_name)
 
       opts = reloptions("q_#{@queue_name}")
 
       assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
       assert_equal "50", opts["autovacuum_vacuum_threshold"]
+      assert_equal "2", opts["autovacuum_vacuum_cost_delay"]
+      assert_in_delta 0.05, opts["autovacuum_analyze_scale_factor"].to_f
+      assert_equal "70", opts["fillfactor"]
     end
 
-    it "applies PGMQ-tuned defaults to the archive table" do
+    it "applies all PGMQ-tuned defaults to the archive table (no fillfactor)" do
       @client.tune_autovacuum(@queue_name)
 
       opts = reloptions("a_#{@queue_name}")
 
       assert_in_delta 0.05, opts["autovacuum_vacuum_scale_factor"].to_f
       assert_equal "50", opts["autovacuum_vacuum_threshold"]
+      assert_equal "5", opts["autovacuum_vacuum_cost_delay"]
+      assert_in_delta 0.05, opts["autovacuum_analyze_scale_factor"].to_f
+      refute opts.key?("fillfactor"), "archive table should not get a fillfactor"
     end
 
-    it "honours custom scale factor and threshold on the queue table" do
-      @client.tune_autovacuum(@queue_name, scale_factor: 0.005, threshold: 25)
+    it "merges queue_settings overrides onto the defaults" do
+      @client.tune_autovacuum(@queue_name, queue_settings: { autovacuum_vacuum_scale_factor: 0.005, fillfactor: 80 })
 
       opts = reloptions("q_#{@queue_name}")
 
+      # Overridden keys take the new value...
       assert_in_delta 0.005, opts["autovacuum_vacuum_scale_factor"].to_f
-      assert_equal "25", opts["autovacuum_vacuum_threshold"]
+      assert_equal "80", opts["fillfactor"]
+      # ...while un-named keys keep the defaults.
+      assert_equal "50", opts["autovacuum_vacuum_threshold"]
+      assert_equal "2", opts["autovacuum_vacuum_cost_delay"]
     end
 
-    it "honours custom archive scale factor and threshold" do
-      @client.tune_autovacuum(@queue_name, archive_scale_factor: 0.02, archive_threshold: 100)
+    it "merges archive_settings overrides onto the defaults" do
+      @client.tune_autovacuum(@queue_name, archive_settings: { autovacuum_vacuum_scale_factor: 0.02 })
 
       opts = reloptions("a_#{@queue_name}")
 
       assert_in_delta 0.02, opts["autovacuum_vacuum_scale_factor"].to_f
-      assert_equal "100", opts["autovacuum_vacuum_threshold"]
+      assert_equal "5", opts["autovacuum_vacuum_cost_delay"]
+    end
+
+    it "accepts string keys in settings hashes" do
+      @client.tune_autovacuum(@queue_name, queue_settings: { "fillfactor" => 90 })
+
+      assert_equal "90", reloptions("q_#{@queue_name}")["fillfactor"]
     end
 
     it "leaves the archive table untouched when archive: false" do
@@ -72,9 +88,7 @@ describe PGMQ::Client::Autovacuum do
       @client.tune_autovacuum(@queue_name)
       @client.tune_autovacuum(@queue_name)
 
-      opts = reloptions("q_#{@queue_name}")
-
-      assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
+      assert_in_delta 0.01, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
     end
 
     it "returns nil" do
@@ -94,17 +108,24 @@ describe PGMQ::Client::Autovacuum do
     end
 
     it "coerces string-like numeric input safely" do
-      @client.tune_autovacuum(@queue_name, scale_factor: "0.03", threshold: "10")
+      @client.tune_autovacuum(@queue_name, queue_settings: { autovacuum_vacuum_scale_factor: "0.03", fillfactor: "85" })
 
       opts = reloptions("q_#{@queue_name}")
 
       assert_in_delta 0.03, opts["autovacuum_vacuum_scale_factor"].to_f
-      assert_equal "10", opts["autovacuum_vacuum_threshold"]
+      assert_equal "85", opts["fillfactor"]
     end
 
-    it "rejects non-numeric scale factor rather than injecting it" do
+    it "rejects non-numeric values rather than injecting them" do
       assert_raises(ArgumentError) do
-        @client.tune_autovacuum(@queue_name, scale_factor: "0.01); DROP TABLE pgmq.meta; --")
+        @client.tune_autovacuum(@queue_name,
+          queue_settings: { autovacuum_vacuum_scale_factor: "0.01); DROP TABLE pgmq.meta; --" })
+      end
+    end
+
+    it "rejects unknown storage parameters rather than injecting them" do
+      assert_raises(ArgumentError) do
+        @client.tune_autovacuum(@queue_name, queue_settings: { "evil) ; DROP TABLE pgmq.meta; --" => 1 })
       end
     end
 
@@ -117,9 +138,7 @@ describe PGMQ::Client::Autovacuum do
       begin
         @client.tune_autovacuum(mixed)
 
-        opts = reloptions("q_#{mixed.downcase}")
-
-        assert_in_delta 0.01, opts["autovacuum_vacuum_scale_factor"].to_f
+        assert_in_delta 0.01, reloptions("q_#{mixed.downcase}")["autovacuum_vacuum_scale_factor"].to_f
       ensure
         @client.drop_queue(mixed)
       end
@@ -130,7 +149,7 @@ describe PGMQ::Client::Autovacuum do
     it "tunes both tables when create is called with tune_autovacuum: true" do
       @client.create(@queue_name, tune_autovacuum: true)
 
-      assert_in_delta 0.01, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "70", reloptions("q_#{@queue_name}")["fillfactor"]
       assert_in_delta 0.05, reloptions("a_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
     end
 
@@ -142,7 +161,8 @@ describe PGMQ::Client::Autovacuum do
     end
 
     it "forwards a Hash of options from create" do
-      @client.create(@queue_name, tune_autovacuum: { scale_factor: 0.002, archive: false })
+      @client.create(@queue_name,
+        tune_autovacuum: { queue_settings: { autovacuum_vacuum_scale_factor: 0.002 }, archive: false })
 
       assert_in_delta 0.002, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
       assert_empty reloptions("a_#{@queue_name}")
@@ -151,7 +171,7 @@ describe PGMQ::Client::Autovacuum do
     it "tunes when create_unlogged is called with tune_autovacuum: true" do
       @client.create_unlogged(@queue_name, tune_autovacuum: true)
 
-      assert_in_delta 0.01, reloptions("q_#{@queue_name}")["autovacuum_vacuum_scale_factor"].to_f
+      assert_equal "70", reloptions("q_#{@queue_name}")["fillfactor"]
     end
 
     it "still returns the created/existed boolean when tuning" do


### PR DESCRIPTION
## Motivation

Follow-up to #131, which added `tune_autovacuum`. That first version set only `autovacuum_vacuum_scale_factor` + `autovacuum_vacuum_threshold`. A busy PGMQ deployment benefits from more — this PR expands the tuned set to what a production setup actually needs (informed by the [pgbus](https://github.com/mhenrixon/pgbus) deployment), and reshapes the API so any storage param can be set.

## What changed

`tune_autovacuum` now applies these per-table defaults:

| Parameter | Queue table (`pgmq.q_…`) | Archive table (`pgmq.a_…`) |
|-----------|--------------------------|----------------------------|
| `autovacuum_vacuum_scale_factor`  | `0.01` | `0.05` |
| `autovacuum_vacuum_threshold`     | `50`   | `50`   |
| `autovacuum_vacuum_cost_delay`    | `2`    | `5`    |
| `autovacuum_analyze_scale_factor` | `0.05` | `0.05` |
| `fillfactor`                      | `70`   | — (append-only, not set) |

New vs #131:
- **`autovacuum_vacuum_cost_delay`** — keep each vacuum pass quick on the hot queue (2), gentler on the append-heavy archive (5).
- **`autovacuum_analyze_scale_factor`** — keep planner stats fresh as the table churns.
- **`fillfactor = 70` on the queue table only.** PGMQ UPDATEs `vt`/`read_ct`/`last_read_at` on *every read*; `vt` is indexed so the UPDATE is not HOT-eligible, and the default `fillfactor=100` bloats pages between vacuums. Archives are append-only, so they get no fillfactor.

## API change (allowed: 0.7.0 is unreleased)

`tune_autovacuum(queue_name, queue_settings: {}, archive: true, archive_settings: {})` replaces the fixed `scale_factor:`/`threshold:`/`archive_*` kwargs. You name only the params you want to change; they're merged onto the per-table defaults. This is extensible to any storage parameter and reads cleanly at the call site. The `tune_autovacuum:` keyword on `create`/`create_unlogged`/`create_partitioned` forwards the same shape.

Since 0.7.0 is unreleased (latest gem is 0.6.2), no released contract changes.

## Safety

- Parameter **names** are allow-listed against the known default keys before interpolation (names can't be bind params).
- Parameter **values** are coerced (`Float` for scale factors, `Integer` otherwise) — non-numeric input raises `ArgumentError` rather than reaching the SQL.
- Both guards are covered by tests, alongside the existing mixed-case-queue and partitioned-parent behavior.

## Tests

19 autovacuum tests (assert all five queue params land, the archive gets no fillfactor, per-table override merging, both injection guards, and the create-flag forms). Full suite green, lint clean.
