### PR TITLE
feat(queue-name): add strict sanitize! and align normalize with stream separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,22 @@
 
 ### Queue Naming
 - **[Feature]** Add `PGMQ::QueueName`, a module that is now the single source of truth for queue-name rules and
-  exposes a three-tier API for deriving valid names from less-trusted input:
+  exposes tiers for deriving valid names from less-trusted input:
   - `PGMQ::QueueName.valid?(name)` / `PGMQ::QueueName.validate!(name)` - the existing strict check (used internally
     by every `PGMQ::Client` operation); `validate!` returns the name when valid and raises
     `PGMQ::Errors::InvalidQueueNameError` otherwise.
-  - `PGMQ::QueueName.normalize(name)` - rewrites a name meant to be valid but using friendly separators
-    (hyphens, colons, dots, spaces become underscores), e.g. a Turbo Stream channel `"chat:room-7"` →
-    `"chat_room_7"`. Raises if the result still can't be valid (empty, or starts with a digit).
-  - `PGMQ::QueueName.sanitize(name)` - coerces arbitrary, untrusted input into a valid name on a best-effort basis;
-    never raises for content (lowercases, replaces illegal runs, prefixes leading digits, truncates to the length
-    limit, falls back to `"queue"` when nothing usable remains).
+  - `PGMQ::QueueName.normalize(name)` - rewrites a name meant to be valid but using friendly separators. Maps
+    hyphens, dots, and colons to underscores, strips any *other* invalid character (so `"a@b"` → `"ab"`, not
+    `"a_b"`), then validates - e.g. a Turbo Stream channel `"chat:room-7"` → `"chat_room_7"`. Raises if the result
+    still can't be valid (empty, or starts with a digit). Colons map to underscores (rather than being stripped) so
+    distinct turbo-rails stream names don't collide on one queue.
+  - `PGMQ::QueueName.sanitize!(name)` - strips every invalid character then validates; raises
+    `InvalidQueueNameError` if nothing valid remains. A SQL-identifier guard for untrusted input: the result is
+    always either a name you know is safe or an exception, never a silent substitute.
+  - `PGMQ::QueueName.sanitize(name)` - the lenient sibling of `sanitize!`: best-effort coercion that never raises for
+    content (lowercases, replaces illegal runs, prefixes leading digits, truncates to the length limit, falls back
+    to `"queue"`). Convenient, but distinct inputs can map to the same name, so prefer `sanitize!` for untrusted
+    input.
 
   `PGMQ::Client#validate_queue_name!` now delegates to `PGMQ::QueueName.validate!`; error messages are unchanged.
 ### Connection Management

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ client.create("a" * 48)          # ✗ Too long (48+ chars)
 
 `PGMQ::Client` always validates the name you pass (via `PGMQ::QueueName.validate!`).
 When the name comes from a friendlier source — a Turbo Stream channel, a slug, or
-untrusted user input — `PGMQ::QueueName` gives you three tiers so you can decide
+untrusted user input — `PGMQ::QueueName` gives you a few tiers so you can decide
 how strict to be:
 
 ```ruby
@@ -455,19 +455,26 @@ PGMQ::QueueName.valid?("orders")          # => true
 PGMQ::QueueName.validate!("my-queue")     # => raises PGMQ::Errors::InvalidQueueNameError
 
 # Tier 2 — normalize a name meant to be valid but using friendly separators.
-# Hyphens/colons/dots/spaces become underscores; raises if the result still
-# can't be valid (empty, or starts with a digit).
+# Hyphens/dots/colons become underscores; any OTHER invalid char is stripped;
+# raises if the result still can't be valid (empty, or starts with a digit).
 PGMQ::QueueName.normalize("chat:room-7")  # => "chat_room_7"
-PGMQ::QueueName.normalize("order events") # => "order_events"
+PGMQ::QueueName.normalize("order.events") # => "order_events"
+PGMQ::QueueName.normalize("a@b")          # => "ab"   (the "@" is dropped, not turned into "_")
 PGMQ::QueueName.normalize("123-go")       # => raises (starts with a digit)
 
-# Tier 3 — sanitize arbitrary, untrusted input. Never raises; always returns a
-# valid name (prefixes leading digits, truncates to length, falls back to "queue").
-PGMQ::QueueName.sanitize("99 Problems!")        # => "q_99_problems"
-PGMQ::QueueName.sanitize("Order-Events:Created") # => "order_events_created"
-PGMQ::QueueName.sanitize("!!!")                  # => "queue"
+# Tier 3 — sanitize! untrusted input: strip every invalid char, then validate.
+# Raises rather than substituting, so it never silently points at a different
+# queue. Use this as a SQL-identifier guard for untrusted input.
+PGMQ::QueueName.sanitize!("orders!!")     # => "orders"
+PGMQ::QueueName.sanitize!("!!!")          # => raises PGMQ::Errors::InvalidQueueNameError
 
-client.create(PGMQ::QueueName.sanitize(params[:topic]))  # safe for user input
+# Tier 3 (lenient) — sanitize never raises; always returns a valid name (prefixes
+# leading digits, truncates to length, falls back to "queue"). Convenient, but
+# distinct inputs can map to the SAME name, so prefer sanitize! for untrusted input.
+PGMQ::QueueName.sanitize("99 Problems!")  # => "q_99_problems"
+PGMQ::QueueName.sanitize("!!!")           # => "queue"
+
+client.create(PGMQ::QueueName.sanitize!(params[:topic]))  # raises on junk rather than guessing
 ```
 
 #### Autovacuum Tuning

--- a/lib/pgmq/queue_name.rb
+++ b/lib/pgmq/queue_name.rb
@@ -5,21 +5,28 @@ module PGMQ
   #
   # PGMQ interpolates a queue's name into PostgreSQL identifiers (it creates tables named +pgmq.q_<name>+ and
   # +pgmq.a_<name>+), so a name has to be a valid, length-bounded SQL identifier. This module is the single source of
-  # truth for those rules and offers three tiers depending on how much you trust the input:
+  # truth for those rules and offers tiers depending on how much you trust the input:
   #
   # 1. {.validate!} / {.valid?} - assert a name is already valid. Use for names you control. {PGMQ::Client} calls
   #    {.validate!} before every operation.
-  # 2. {.normalize} - lightly rewrite a name that is *meant* to be valid but uses a friendlier separator (hyphens,
-  #    colons, dots, spaces), e.g. a Turbo Stream channel like +"chat:room-7"+. Raises if the result still can't be a
-  #    valid name (empty, or starts with a digit).
-  # 3. {.sanitize} - coerce *arbitrary, untrusted* input into a valid name on a best-effort basis. Never raises for
-  #    content; always returns a usable identifier (falling back to a default when nothing usable remains).
+  # 2. {.normalize} - lightly rewrite a name that is *meant* to be valid but uses a friendlier separator. Maps the
+  #    common stream separators (hyphens, dots, colons) to underscores, strips any other invalid character, then
+  #    validates - so a Turbo Stream channel like +"chat:room-7"+ becomes +"chat_room_7"+. Raises if the result still
+  #    can't be a valid name (empty, or starts with a digit).
+  # 3. {.sanitize!} - coerce *untrusted* input into a valid name by stripping every invalid character, then validate.
+  #    Raises if nothing valid remains. Use this as a SQL-identifier guard: the result is always either a name you
+  #    know is safe, or an exception - never a silent substitute.
+  # 4. {.sanitize} - the lenient sibling of {.sanitize!}: best-effort coercion that *never* raises for content and
+  #    always returns a usable identifier (falling back to a default). Convenient, but see the collision caveat on
+  #    the method - distinct inputs can map to the same name.
   #
   # @example
-  #   PGMQ::QueueName.valid?("orders")          # => true
-  #   PGMQ::QueueName.validate!("my-queue")     # => raises InvalidQueueNameError
-  #   PGMQ::QueueName.normalize("chat:room-7")  # => "chat_room_7"
-  #   PGMQ::QueueName.sanitize("99 Problems!")  # => "q_99_problems"
+  #   PGMQ::QueueName.valid?("orders")           # => true
+  #   PGMQ::QueueName.validate!("my-queue")      # => raises InvalidQueueNameError
+  #   PGMQ::QueueName.normalize("chat:room-7")   # => "chat_room_7"
+  #   PGMQ::QueueName.sanitize!("orders!!")      # => "orders"
+  #   PGMQ::QueueName.sanitize!("!!!")           # => raises InvalidQueueNameError
+  #   PGMQ::QueueName.sanitize("99 Problems!")   # => "q_99_problems"
   module QueueName
     # Maximum queue name length. PGMQ creates tables with prefixes (+q_+, +a_+) and PostgreSQL caps identifiers at 63
     # characters; PGMQ enforces 48 to leave room for those prefixes and suffixes.
@@ -71,35 +78,60 @@ module PGMQ
         "and contain only letters, digits, and underscores"
     end
 
-    # Rewrites a name that is meant to be valid but uses friendlier separators.
+    # Rewrites a name that is meant to be valid but uses friendlier separators, then validates it.
     #
-    # Trims surrounding whitespace, replaces any run of non-identifier characters with a single underscore, and
-    # collapses repeated underscores. This turns names like +"chat:room-7"+ or +"order events"+ into +"chat_room_7"+
-    # / +"order_events"+. The result is then validated, so names that still can't be valid (empty, or starting with a
-    # digit) raise rather than being silently mangled.
+    # Maps the common stream-name separators - hyphens, dots, and colons - to underscores, strips any *other* invalid
+    # character, then collapses repeated underscores and trims them from the ends. So +"chat:room-7"+ becomes
+    # +"chat_room_7"+ and +"order.events"+ becomes +"order_events"+, while a stray +"a@b"+ becomes +"ab"+ (the +@+ is
+    # dropped, not turned into a separator). The result is validated, so names that still can't be valid (empty, or
+    # starting with a digit) raise rather than being silently mangled.
+    #
+    # Colons in particular are the turbo-rails stream-name separator, so they are mapped to a safe character rather
+    # than stripped - otherwise +"a:b"+ and +"ab"+ would collide on the same queue.
     #
     # @param name [String, #to_s] a name using friendly separators
     # @return [String] the normalized, validated queue name
     # @raise [PGMQ::Errors::InvalidQueueNameError] if the normalized result is not a valid queue name
     def normalize(name)
-      normalized = name.to_s.strip
-        .gsub(/[^a-zA-Z0-9_]+/, "_").squeeze("_")
-        .gsub(/\A_+|_+\z/, "")
+      str = name.to_s
+      return validate!(str) if str.match?(PATTERN)
+
+      normalized = str
+        .gsub(/[-.:]/, "_")          # hyphens / dots / colons -> underscores
+        .gsub(/[^a-zA-Z0-9_]/, "")   # strip any remaining invalid character
+        .squeeze("_")                # collapse consecutive underscores
+        .gsub(/\A_+|_+\z/, "")       # trim leading / trailing underscores
 
       validate!(normalized)
     end
 
-    # Coerces arbitrary, untrusted input into a valid queue name on a best-effort basis.
+    # Strips every invalid character from untrusted input, then validates the result.
     #
-    # Unlike {.normalize}, this never raises for content: it lowercases, replaces every illegal character run with an
-    # underscore, strips leading/trailing underscores, prefixes {SANITIZE_PREFIX} when the first surviving character
-    # is not a valid identifier start (e.g. a digit), truncates to fit {MAX_LENGTH}, and falls back to
-    # {SANITIZE_FALLBACK} when nothing usable remains. The return value always satisfies {.valid?}.
-    #
-    # Use for names derived from user input or external systems where you would rather get a deterministic, safe
-    # queue name than an exception.
+    # This is the SQL-identifier guard: it removes anything outside +[A-Za-z0-9_]+ and passes the remainder through
+    # {.validate!}. If nothing valid remains (empty result, leading digit, too long) it raises, so a caller can never
+    # accidentally operate on a different queue than intended. Use this for names from untrusted sources (URL params,
+    # external systems) where a wrong-but-valid name would be worse than an error.
     #
     # @param name [String, #to_s] untrusted input
+    # @return [String] the sanitized, validated queue name
+    # @raise [PGMQ::Errors::InvalidQueueNameError] if nothing valid remains after stripping
+    def sanitize!(name)
+      validate!(name.to_s.gsub(/[^a-zA-Z0-9_]/, ""))
+    end
+
+    # Best-effort coercion of arbitrary input into a valid queue name; the lenient sibling of {.sanitize!}.
+    #
+    # Never raises for content: it lowercases, replaces every illegal character run with an underscore, trims
+    # underscores, prefixes {SANITIZE_PREFIX} when the first surviving character is not a valid identifier start (e.g.
+    # a digit), truncates to fit {MAX_LENGTH}, and falls back to {SANITIZE_FALLBACK} when nothing usable remains. The
+    # return value always satisfies {.valid?}.
+    #
+    # @note Because it coerces rather than rejects, distinct inputs can map to the *same* name (e.g. +"a/b"+ and
+    #   +"a-b"+ both become +"a_b"+; +"!!!"+ and +""+ both become +"queue"+). If your name selects a queue table,
+    #   that means two logically different inputs could share one queue. When that matters - especially for untrusted
+    #   input - prefer {.sanitize!}, which raises instead of substituting.
+    #
+    # @param name [String, #to_s] arbitrary input
     # @return [String] a guaranteed-valid queue name
     def sanitize(name)
       cleaned = name.to_s.downcase

--- a/test/lib/pgmq/queue_name_test.rb
+++ b/test/lib/pgmq/queue_name_test.rb
@@ -55,18 +55,29 @@ describe PGMQ::QueueName do
   end
 
   describe ".normalize" do
-    it "replaces friendly separators with underscores" do
+    it "maps hyphens, dots, and colons to underscores" do
       assert_equal "chat_room_7", PGMQ::QueueName.normalize("chat:room-7")
-      assert_equal "order_events", PGMQ::QueueName.normalize("order events")
-      assert_equal "Foo_Bar", PGMQ::QueueName.normalize("Foo.Bar")
+      assert_equal "order_events", PGMQ::QueueName.normalize("order.events")
+      assert_equal "Foo_Bar", PGMQ::QueueName.normalize("Foo-Bar")
+    end
+
+    it "strips other invalid characters rather than turning them into separators" do
+      # An "@" is dropped, not mapped to "_", so "a@b" -> "ab" (not "a_b").
+      assert_equal "ab", PGMQ::QueueName.normalize("a@b")
+      assert_equal "orderevents", PGMQ::QueueName.normalize("order events")
+    end
+
+    it "maps colons to underscores so distinct turbo-rails streams do not collide" do
+      # "a:b" must not collapse onto "ab" (the colon is the turbo-rails stream separator).
+      refute_equal PGMQ::QueueName.normalize("ab"), PGMQ::QueueName.normalize("a:b")
+      assert_equal "a_b", PGMQ::QueueName.normalize("a:b")
     end
 
     it "collapses repeated separators into a single underscore" do
-      assert_equal "a_b_c", PGMQ::QueueName.normalize("a--b__c")
+      assert_equal "a_b_c", PGMQ::QueueName.normalize("a--b..c")
     end
 
-    it "trims leading and trailing separators and whitespace" do
-      assert_equal "spaced", PGMQ::QueueName.normalize("  spaced  ")
+    it "trims leading and trailing separators" do
       assert_equal "edge", PGMQ::QueueName.normalize("--edge--")
     end
 
@@ -84,6 +95,32 @@ describe PGMQ::QueueName do
 
     it "raises when the normalized result exceeds the length limit" do
       assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.normalize("a-" * 30) }
+    end
+  end
+
+  describe ".sanitize!" do
+    it "strips invalid characters then returns the validated name" do
+      assert_equal "orders", PGMQ::QueueName.sanitize!("orders!!")
+      assert_equal "ab", PGMQ::QueueName.sanitize!("a-b")
+      assert_equal "myqueue", PGMQ::QueueName.sanitize!("my.queue")
+    end
+
+    it "leaves an already-valid name unchanged" do
+      assert_equal "My_Queue_1", PGMQ::QueueName.sanitize!("My_Queue_1")
+    end
+
+    it "raises rather than substituting when nothing valid remains" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.sanitize!("!!!") }
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.sanitize!("") }
+    end
+
+    it "raises when the stripped result would start with a digit" do
+      # "123" survives stripping but is not a valid identifier — sanitize! must NOT silently mangle it.
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.sanitize!("123") }
+    end
+
+    it "raises when the stripped result is too long" do
+      assert_raises(PGMQ::Errors::InvalidQueueNameError) { PGMQ::QueueName.sanitize!("a" * 80) }
     end
   end
 


### PR DESCRIPTION
## Motivation

Follow-up to #132, which added `PGMQ::QueueName`. After comparing against a real consumer ([pgbus](https://github.com/mhenrixon/pgbus)'s `QueueNameValidator`), two refinements make the helpers safer and match the rules a downstream user actually needs — so it can delegate instead of keeping its own copy.

## What changed

**`normalize` — match stream-separator semantics.** It now maps **only** hyphens, dots, and colons to underscores, and **strips** any other invalid character, instead of turning every invalid run into an underscore:

```ruby
PGMQ::QueueName.normalize("a@b")          # => "ab"   (was "a_b")
PGMQ::QueueName.normalize("chat:room-7")  # => "chat_room_7"
```

Colons map to `_` (rather than being stripped) on purpose: `:` is the turbo-rails stream-name separator, so `"a:b"` must stay distinct from `"ab"` rather than collapsing onto the same queue. Already-valid names pass through untouched.

**Add `sanitize!` — a strict SQL-identifier guard.** It strips every invalid character then validates, **raising** `InvalidQueueNameError` if nothing valid remains:

```ruby
PGMQ::QueueName.sanitize!("orders!!")  # => "orders"
PGMQ::QueueName.sanitize!("!!!")       # => raises  (never silently substitutes)
```

The existing lenient `sanitize` stays (never raises, falls back to `"queue"`), but its docs now warn that distinct inputs can map to the same name and point callers at `sanitize!` for untrusted input — closing the "silent fallback points SQL at the wrong table" gap.

## Compatibility

0.7.0 is unreleased (latest gem is 0.6.2), so refining `normalize` is not a released-contract change. `sanitize!` is purely additive.

## Tests

30 `QueueName` tests: a new `.sanitize!` block (strip-then-validate, raises on empty / leading-digit / too-long) and reworked `.normalize` specs covering the strip-vs-replace rule and the colon-collision guarantee. Full suite green, lint clean.
