### PR TITLE
feat(connection): add pool reload to evict a poisoned connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Connection Pool
+- **[Feature]** Add `PGMQ::Connection#reload` (and `PGMQ::Client#reload`, which delegates to it). It drops every
+  connection currently in the pool and lets the pool rebuild fresh ones lazily on the next checkout — unlike `#close`,
+  which shuts the pool down permanently. Use it to recover from a connection that libpq still reports as
+  `CONNECTION_OK` but is in fact wedged, e.g. after a wall-clock `Timeout.timeout` interrupted a query mid-flight and
+  left the socket poisoned so it re-hangs on reuse. `#verify_connection!` cannot catch that case (the connection does
+  not report `CONNECTION_BAD`), so the caller must discard it explicitly; `reload` is the safe, pool-wide way to do so.
+  Connections it drops are closed. Implemented via `ConnectionPool#reload`.
+
 ## 0.7.0 (2026-06-15)
 
 ### Queue Naming

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -84,6 +84,17 @@ module PGMQ
       @connection.close
     end
 
+    # Drops every pooled connection and rebuilds lazily on the next checkout,
+    # leaving the pool usable (unlike {#close}). Use it to discard a connection
+    # that reports +CONNECTION_OK+ but is actually wedged — e.g. after a
+    # wall-clock timeout interrupted a query mid-flight and left the socket
+    # poisoned so it would re-hang on reuse. See {PGMQ::Connection#reload}.
+    #
+    # @return [void]
+    def reload
+      @connection.reload
+    end
+
     # Returns connection pool statistics
     #
     # @return [Hash] statistics about the connection pool

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -178,6 +178,29 @@ module PGMQ
       @pool.shutdown { |conn| conn.close unless conn.finished? }
     end
 
+    # Drops every connection currently in the pool and lets the pool build fresh
+    # ones lazily on the next checkout. Unlike {#close} (which shuts the pool
+    # down permanently), the pool stays usable afterwards.
+    #
+    # Use this to recover from a connection that libpq still reports as
+    # +CONNECTION_OK+ but which is in fact wedged — e.g. after a wall-clock
+    # timeout (+Timeout.timeout+) interrupted a query mid-flight, leaving the
+    # socket poisoned so it re-hangs on reuse. {#verify_connection!} cannot catch
+    # that case (the connection does not report +CONNECTION_BAD+), so the caller
+    # must discard it explicitly; +reload+ is the safe, pool-wide way to do so.
+    #
+    # @return [void]
+    # @example Discard the pool after a read had to be force-interrupted
+    #   begin
+    #     Timeout.timeout(5) { client.read("q") }
+    #   rescue Timeout::Error
+    #     connection.reload # drop the possibly-poisoned pooled connections
+    #     raise
+    #   end
+    def reload
+      @pool.reload { |conn| conn.close unless conn.finished? }
+    end
+
     # Returns connection pool statistics
     #
     # @return [Hash] statistics about the connection pool

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -190,9 +190,9 @@ module PGMQ
     # must discard it explicitly; +reload+ is the safe, pool-wide way to do so.
     #
     # @return [void]
-    # @example Discard the pool after a read had to be force-interrupted
+    # @example Discard the pool after a query had to be force-interrupted
     #   begin
-    #     Timeout.timeout(5) { client.read("q") }
+    #     Timeout.timeout(5) { connection.with_connection { |conn| conn.exec("SELECT ...") } }
     #   rescue Timeout::Error
     #     connection.reload # drop the possibly-poisoned pooled connections
     #     raise

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -94,6 +94,69 @@ describe PGMQ::Connection do
     end
   end
 
+  describe "pool reload" do
+    it "keeps the pool usable (unlike close)" do
+      connection = PGMQ::Connection.new(@conn_params, pool_size: 2)
+      connection.with_connection { |conn| conn.exec("SELECT 1") }
+
+      connection.reload
+
+      # A closed pool would raise here; a reloaded pool rebuilds lazily.
+      result = connection.with_connection { |conn| conn.exec("SELECT 1")[0]["?column?"] }
+
+      assert_equal "1", result
+      connection.close
+    end
+
+    it "replaces the pooled backend connections" do
+      connection = PGMQ::Connection.new(@conn_params, pool_size: 1)
+
+      pid_before = connection.with_connection { |conn| conn.exec("SELECT pg_backend_pid()")[0]["pg_backend_pid"] }
+
+      connection.reload
+
+      pid_after = connection.with_connection { |conn| conn.exec("SELECT pg_backend_pid()")[0]["pg_backend_pid"] }
+
+      # A brand-new backend connection after reload has a different backend PID.
+      refute_equal pid_before, pid_after
+      connection.close
+    end
+
+    it "closes the connections it drops" do
+      connection = PGMQ::Connection.new(@conn_params, pool_size: 1)
+
+      dropped = connection.with_connection { |conn| conn }
+      refute dropped.finished?
+
+      connection.reload
+
+      assert dropped.finished?, "reload should close the connection it evicted"
+      connection.close
+    end
+
+    it "reports full availability again after reload" do
+      connection = PGMQ::Connection.new(@conn_params, pool_size: 3)
+      connection.with_connection { |conn| conn.exec("SELECT 1") }
+
+      connection.reload
+
+      assert_equal 3, connection.stats[:available]
+      connection.close
+    end
+
+    it "is exposed on the client and delegates to the connection" do
+      client = PGMQ::Client.new(@conn_params, pool_size: 1)
+
+      client.with_connection { |conn| conn.exec("SELECT 1") }
+      client.reload
+
+      result = client.with_connection { |conn| conn.exec("SELECT 1")[0]["?column?"] }
+
+      assert_equal "1", result
+      client.close
+    end
+  end
+
   describe "connection pool timeout" do
     it "raises error when pool is exhausted" do
       client = PGMQ::Client.new(@conn_params, pool_size: 1, pool_timeout: 0.5)

--- a/test/lib/pgmq/connection_test.rb
+++ b/test/lib/pgmq/connection_test.rb
@@ -126,11 +126,12 @@ describe PGMQ::Connection do
       connection = PGMQ::Connection.new(@conn_params, pool_size: 1)
 
       dropped = connection.with_connection { |conn| conn }
-      refute dropped.finished?
+
+      refute_predicate dropped, :finished?
 
       connection.reload
 
-      assert dropped.finished?, "reload should close the connection it evicted"
+      assert_predicate dropped, :finished?, "reload should close the connection it evicted"
       connection.close
     end
 


### PR DESCRIPTION
## Summary

Adds `PGMQ::Connection#reload` (and `PGMQ::Client#reload`, which delegates to it) to drop every connection currently in the pool and rebuild fresh ones lazily on the next checkout. Unlike `#close` (which calls `ConnectionPool#shutdown` and closes the pool **permanently** — subsequent checkouts raise `PoolShuttingDownError`), `#reload` leaves the pool usable.

## Motivation

A pooled connection can be wedged while libpq still reports it as `CONNECTION_OK`. The clearest case: a caller wraps a read in a wall-clock `Timeout.timeout` as a last-resort bound (e.g. on a platform where libpq's `tcp_user_timeout` is a no-op, like macOS/BSD/Windows). When that `Timeout` fires on a genuinely hung socket, `Thread#raise` interrupts the query mid-flight and leaves the socket poisoned — the connection still reports `CONNECTION_OK` but **re-hangs on the next use**.

`#verify_connection!` cannot catch this: it only resets a connection that is `finished?` or reports `CONNECTION_BAD`. So the caller has no safe way, today, to discard such a connection without tearing down the whole client. `#reload` fills that gap:

```ruby
begin
  Timeout.timeout(5) { client.read("q") }
rescue Timeout::Error
  client.reload   # drop the possibly-poisoned pooled connections; pool stays usable
  raise
end
```

## Implementation

Thin wrapper over `ConnectionPool#reload` (which the `connection_pool` gem provides precisely for "drop all connections, rebuild lazily"). Connections it drops are closed (`conn.close unless conn.finished?`), mirroring `#close`.

## Tests

`test/lib/pgmq/connection_test.rb` — new `describe "pool reload"`:
- pool stays usable after reload (a `SELECT 1` succeeds where a closed pool would raise)
- the backend connection is actually replaced (different `pg_backend_pid()`)
- dropped connections are closed
- availability returns to full after reload
- `Client#reload` is exposed and delegates to the connection

All green locally (`41 runs, 53 assertions, 0 failures, 0 errors` for the file).

## Context

Surfaced while making [pgbus](https://github.com/mhenrixon/pgbus) bound its reads with libpq-native timeouts instead of Ruby `Timeout`. On platforms where the libpq socket bound is unavailable, pgbus keeps a `Timeout` fallback and wants to evict the poisoned connection when it fires — which needs exactly this primitive. Filed as the upstream half of that work.
