### PR TITLE
Track latest Ruby 4.0 patch in CI instead of pinning 4.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Run yard-lint
         run: bundle exec yard-lint lib/
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop


### PR DESCRIPTION
The `yard-lint` and `rubocop` jobs pinned an exact patch release (`4.0.5`), so they needed a manual bump on every 4.0.x release.

Use `'4.0'` instead — setup-ruby resolves the newest 4.0 patch automatically, matching how the test matrix already declares its Rubies.

Coverage already runs on Ruby 4.0 and the lockfile is committed with SimpleCov 1.0.0 (from #146), so no other changes needed here.