### PR TITLE
Enable new yard-lint 1.10 documentation linters

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -61,6 +61,26 @@ Documentation/BlankLineBeforeDefinition:
     SingleBlankLine: true
     OrphanedDocs: true
 
+Documentation/DuplicateNamespaceComment:
+  Description: Detects namespaces documented with a YARD comment in more than one file.
+  Enabled: true
+  Severity: error
+
+Documentation/UnderfilledLines:
+  Description: Detects documentation prose that wraps too early and wastes horizontal space.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength so documentation prose wraps to the same
+  # width as code.
+  MaxLength: 120
+
+Documentation/LineLength:
+  Description: Detects documentation lines that exceed the maximum length.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength.
+  MaxLength: 120
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.
@@ -141,7 +161,7 @@ Tags/OptionTags:
 Tags/ExampleSyntax:
   Description: Validates Ruby syntax in @example tags.
   Enabled: true
-  Severity: warning
+  Severity: error
 
 Tags/RedundantParamDescription:
   Description: Detects meaningless parameter descriptions that add no value.

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -54,11 +54,11 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    yard (0.9.38)
-    yard-lint (1.4.0)
+    yard (0.9.45)
+    yard-lint (1.10.1)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
-    zeitwerk (2.7.4)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   ruby
@@ -74,6 +74,7 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -94,9 +95,9 @@ CHECKSUMS
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
-  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
-  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
+  yard-lint (1.10.1) sha256=172ea1905304580bd515c093d82831ec4889e725100c49d5bf77e62101f49129
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
-  4.0.3
+  4.0.17

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -178,16 +178,13 @@ module PGMQ
       @pool.shutdown { |conn| conn.close unless conn.finished? }
     end
 
-    # Drops every connection currently in the pool and lets the pool build fresh
-    # ones lazily on the next checkout. Unlike {#close} (which shuts the pool
-    # down permanently), the pool stays usable afterwards.
+    # Drops every connection currently in the pool and lets the pool build fresh ones lazily on the next checkout.
+    # Unlike {#close} (which shuts the pool down permanently), the pool stays usable afterwards.
     #
-    # Use this to recover from a connection that libpq still reports as
-    # +CONNECTION_OK+ but which is in fact wedged — e.g. after a wall-clock
-    # timeout (+Timeout.timeout+) interrupted a query mid-flight, leaving the
-    # socket poisoned so it re-hangs on reuse. {#verify_connection!} cannot catch
-    # that case (the connection does not report +CONNECTION_BAD+), so the caller
-    # must discard it explicitly; +reload+ is the safe, pool-wide way to do so.
+    # Use this to recover from a connection that libpq still reports as +CONNECTION_OK+ but which is in fact wedged —
+    # e.g. after a wall-clock timeout (+Timeout.timeout+) interrupted a query mid-flight, leaving the socket poisoned so
+    # it re-hangs on reuse. {#verify_connection!} cannot catch that case (the connection does not report
+    # +CONNECTION_BAD+), so the caller must discard it explicitly; +reload+ is the safe, pool-wide way to do so.
     #
     # @return [void]
     # @example Discard the pool after a query had to be force-interrupted


### PR DESCRIPTION
Updates yard-lint to 1.10.1 and enables the new documentation linters (`DuplicateNamespaceComment`, `UnderfilledLines` as errors; `ExampleSyntax` to error), with `MaxLength` aligned to this project's RuboCop `Layout/LineLength`. Fixes every offense they surface. `bundle exec yard-lint lib/` reports `No offenses found`.