### PR TITLE
Standardize yard-lint config (em-dash substitution as error)

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -81,6 +81,14 @@ Documentation/LineLength:
   # Aligned with RuboCop's Layout/LineLength.
   MaxLength: 120
 
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.

--- a/lib/pgmq/client.rb
+++ b/lib/pgmq/client.rb
@@ -84,11 +84,10 @@ module PGMQ
       @connection.close
     end
 
-    # Drops every pooled connection and rebuilds lazily on the next checkout,
-    # leaving the pool usable (unlike {#close}). Use it to discard a connection
-    # that reports +CONNECTION_OK+ but is actually wedged — e.g. after a
-    # wall-clock timeout interrupted a query mid-flight and left the socket
-    # poisoned so it would re-hang on reuse. See {PGMQ::Connection#reload}.
+    # Drops every pooled connection and rebuilds lazily on the next checkout, leaving the pool usable (unlike {#close}).
+    # Use it to discard a connection that reports +CONNECTION_OK+ but is actually wedged - e.g. after a wall-clock
+    # timeout interrupted a query mid-flight and left the socket poisoned so it would re-hang on reuse. See
+    # {PGMQ::Connection#reload}.
     #
     # @return [void]
     def reload

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -186,7 +186,7 @@ module PGMQ
       # or `nil` on timeout.
       #
       # @note Orchestration (retry loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility.
-      #   This method is a thin primitive — it listens once, waits, and returns.
+      #   This method is a thin primitive - it listens once, waits, and returns.
       #
       # @param queue_name [String] name of the queue (must have notifications enabled via {#enable_notify_insert})
       # @param timeout [Numeric, nil] seconds to wait; `nil` blocks indefinitely

--- a/lib/pgmq/connection.rb
+++ b/lib/pgmq/connection.rb
@@ -181,7 +181,7 @@ module PGMQ
     # Drops every connection currently in the pool and lets the pool build fresh ones lazily on the next checkout.
     # Unlike {#close} (which shuts the pool down permanently), the pool stays usable afterwards.
     #
-    # Use this to recover from a connection that libpq still reports as +CONNECTION_OK+ but which is in fact wedged —
+    # Use this to recover from a connection that libpq still reports as +CONNECTION_OK+ but which is in fact wedged -
     # e.g. after a wall-clock timeout (+Timeout.timeout+) interrupted a query mid-flight, leaving the socket poisoned so
     # it re-hangs on reuse. {#verify_connection!} cannot catch that case (the connection does not report
     # +CONNECTION_BAD+), so the caller must discard it explicitly; +reload+ is the safe, pool-wide way to do so.


### PR DESCRIPTION
Enables `Documentation/TextSubstitution` (em-dash `—` and en-dash `–` -> `-`) as an **error**, standardizing it across the ecosystem, and replaces the existing em/en-dashes in documentation. `bundle exec yard-lint lib/` reports `No offenses found`.