### PR TITLE
Standardize Tags/Order to the expanded EnforcedOrder

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -97,9 +97,15 @@ Tags/Order:
   EnforcedOrder:
   - param
   - option
+  - yield
+  - yieldparam
+  - yieldreturn
   - return
   - raise
+  - see
   - example
+  - note
+  - todo
 
 Tags/InvalidTypes:
   Description: Validates type definitions in @param, @return, @option tags.

--- a/lib/pgmq/client/consumer.rb
+++ b/lib/pgmq/client/consumer.rb
@@ -235,8 +235,6 @@ module PGMQ
       # next), `read_grouped_head` surfaces the leading edge of every group in one call - useful for detecting
       # head-of-line stalls or building per-group progress dashboards.
       #
-      # @note Requires PGMQ v1.11.1+.
-      #
       # @param queue_name [String] name of the queue
       # @param vt [Integer] visibility timeout in seconds
       # @param qty [Integer] maximum number of groups to sample
@@ -254,6 +252,7 @@ module PGMQ
       #   heads.each do |msg|
       #     alert_if_stuck(msg) if msg.enqueued_at < Time.now - 3600
       #   end
+      # @note Requires PGMQ v1.11.1+.
       def read_grouped_head(queue_name, vt: DEFAULT_VT, qty: 1)
         validate_queue_name!(queue_name)
 

--- a/lib/pgmq/client/maintenance.rb
+++ b/lib/pgmq/client/maintenance.rb
@@ -66,10 +66,6 @@ module PGMQ
       # If the archive table is already partitioned the function returns without error (idempotent). If the archive
       # table does not exist it also returns without error.
       #
-      # @note Requires the `pg_partman` PostgreSQL extension. If pg_partman is not installed and the archive table
-      #   exists, the call raises `PGMQ::Errors::ConnectionError`. If the archive table does not exist the call
-      #   succeeds (returns nil) without touching pg_partman, so no extension is needed in that case.
-      #
       # @param queue_name [String] name of the queue whose archive table to convert
       # @param partition_interval [String] partition interval passed to pg_partman (default: "10000" rows or a time
       #   expression such as "daily" / "1 month")
@@ -87,6 +83,9 @@ module PGMQ
       #     partition_interval: "daily",
       #     retention_interval: "30 days"
       #   )
+      # @note Requires the `pg_partman` PostgreSQL extension. If pg_partman is not installed and the archive table
+      #   exists, the call raises `PGMQ::Errors::ConnectionError`. If the archive table does not exist the call
+      #   succeeds (returns nil) without touching pg_partman, so no extension is needed in that case.
       def convert_archive_partitioned(
         queue_name,
         partition_interval: "10000",
@@ -185,9 +184,6 @@ module PGMQ
       # The return value mirrors `PG::Connection#wait_for_notify`: the channel name string on success,
       # or `nil` on timeout.
       #
-      # @note Orchestration (retry loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility.
-      #   This method is a thin primitive - it listens once, waits, and returns.
-      #
       # @param queue_name [String] name of the queue (must have notifications enabled via {#enable_notify_insert})
       # @param timeout [Numeric, nil] seconds to wait; `nil` blocks indefinitely
       # @return [String, nil] notification channel name, or `nil` if the timeout expired
@@ -205,6 +201,8 @@ module PGMQ
       #   client.wait_for_notify("orders", timeout: 5) do |channel, pid, payload|
       #     puts "Notified on #{channel} by backend #{pid}"
       #   end
+      # @note Orchestration (retry loop, reconnect-on-drop, graceful shutdown) is the caller's responsibility.
+      #   This method is a thin primitive - it listens once, waits, and returns.
       def wait_for_notify(queue_name, timeout: nil)
         validate_queue_name!(queue_name)
         # PGMQ trigger fires pg_notify('pgmq.q_<queue>.INSERT', NULL)

--- a/lib/pgmq/queue_name.rb
+++ b/lib/pgmq/queue_name.rb
@@ -126,13 +126,12 @@ module PGMQ
     # a digit), truncates to fit {MAX_LENGTH}, and falls back to {SANITIZE_FALLBACK} when nothing usable remains. The
     # return value always satisfies {.valid?}.
     #
+    # @param name [String, #to_s] arbitrary input
+    # @return [String] a guaranteed-valid queue name
     # @note Because it coerces rather than rejects, distinct inputs can map to the *same* name (e.g. +"a/b"+ and
     #   +"a-b"+ both become +"a_b"+; +"!!!"+ and +""+ both become +"queue"+). If your name selects a queue table,
     #   that means two logically different inputs could share one queue. When that matters - especially for untrusted
     #   input - prefer {.sanitize!}, which raises instead of substituting.
-    #
-    # @param name [String, #to_s] arbitrary input
-    # @return [String] a guaranteed-valid queue name
     def sanitize(name)
       cleaned = name.to_s.downcase
         .gsub(/[^a-z0-9_]+/, "_").squeeze("_")


### PR DESCRIPTION
Adopts the expanded `Tags/Order` `EnforcedOrder` (`param, option, yield*, return, raise, see, example, note, todo`) as the ecosystem standard, and reorders the affected docstrings to match. `bundle exec yard-lint lib/` reports `No offenses found`.