### PR TITLE
chore(deps): allow connection_pool 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.2 (Unreleased)
+
+### Dependencies
+- **[Change]** Loosen the `connection_pool` runtime dependency from `~> 2.4` to `>= 2.4, < 4` so applications can
+  upgrade to `connection_pool` 3.x. The gem only uses `ConnectionPool.new(size:, timeout:)`, `#with`, `#shutdown`,
+  `#reload`, `#available` and the `TimeoutError` / `PoolShuttingDownError` classes, all of which are unchanged in 3.x
+  (the 3.0 breaking change was positional-to-keyword arguments on `#checkout` / `#reap`, which are not used here).
+  The lockfile now resolves to 3.0.2 so CI exercises the new major.
+
 ## 0.7.1 (2026-07-09)
 
 ### Connection Pool

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pgmq-ruby (0.7.1)
-      connection_pool (~> 2.4)
+      connection_pool (>= 2.4, < 4)
       pg (~> 1.5)
       zeitwerk (~> 2.6)
 
@@ -13,7 +13,7 @@ GEM
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     console (1.37.0)
       fiber-annotation
       fiber-local (~> 1.1)

--- a/pgmq-ruby.gemspec
+++ b/pgmq-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime dependencies
-  spec.add_dependency "connection_pool", "~> 2.4"
+  spec.add_dependency "connection_pool", ">= 2.4", "< 4"
   spec.add_dependency "pg", "~> 1.5"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end


### PR DESCRIPTION
## Summary

- Loosen the `connection_pool` runtime dependency from `~> 2.4` to `>= 2.4, < 4` so downstream apps can move to connection_pool 3.x (the `~> 2.4` pin currently blocks that upgrade).
- Bump `Gemfile.lock` to connection_pool 3.0.2 so CI exercises the new major.
- CHANGELOG entry under 0.7.2 (Unreleased).

## Why it is safe

`lib/pgmq/connection.rb` only uses `ConnectionPool.new(size:, timeout:)`, `#with`, `#shutdown`, `#reload`, `#available`, `ConnectionPool::TimeoutError` and `ConnectionPool::PoolShuttingDownError`. All of these are unchanged in 3.x — the only breaking change in 3.0 was positional → keyword arguments on `#checkout` / `#reap` (and `TimedStack`), which pgmq-ruby never calls. connection_pool 3 requires Ruby >= 3.2; this gem already requires >= 3.3.

## Test plan

- [x] Full suite locally against connection_pool 3.0.2: 405 runs, 874 assertions, 0 failures, 97.35% line coverage (the 10 `pgmq.read_grouped_head` errors are the pre-existing local PGMQ 1.11 baseline).
- [x] rubocop clean on the gemspec.
- [ ] CI matrix (Ruby 3.3/3.4/4.0 × PG 14–18) now runs on 3.0.2.

https://claude.ai/code/session_01W2ZfGRE4s49wLm7vkPhHXJ